### PR TITLE
Hide Group type.

### DIFF
--- a/relational-query-HDBC-pgTest/example/1/queryExample.hs
+++ b/relational-query-HDBC-pgTest/example/1/queryExample.hs
@@ -3,7 +3,7 @@
 
 import Database.Record
 
-import Database.Relational.Query
+import Database.Relational.Query hiding (Group)
 import Database.HDBC (IConnection, SqlValue)
 import Data.Int (Int32)
 


### PR DESCRIPTION
relational-query-HDBC-pgTest/example1/queryExample.hs で、
`Database.Relational.Query.Context` の `Group` 型(5b4e2321e89838f2dfccd65131e48a4283176a7c で追加された)と、
relational-query-HDBC-pgTest/example1 の `Group` 型が被っていてコンパイルが通らなくなっていたので、`hiding (Group)` しました。
