### PR TITLE
Omit 'AS' keyword from table alias for Oracle DB.

### DIFF
--- a/relational-join/src/Database/Relational/Query/Sub.hs
+++ b/relational-join/src/Database/Relational/Query/Sub.hs
@@ -232,8 +232,7 @@ columnFromId qi i = qi <.> columnN i
 qualifiedSQLas :: Qualified ShowS -> ShowS
 qualifiedSQLas q =
   showUnwords
-  [unQualify q, showWordSQL AS,
-   (showQualifier (qualifier q) ++)]
+  [unQualify q, (showQualifier (qualifier q) ++)]
 
 -- | Width of 'Qualified' 'SubQUery'.
 queryWidth :: Qualified SubQuery -> Int


### PR DESCRIPTION
Oracle ではテーブルの別名をつけるときに 'AS' キーワードがあるとエラーになってしまうので、 'AS' キーワードを省略するようにしました。

例えば、

``` sql
SELECT T0.item_name AS f0 FROM EXAMPLE.item AS T0 WHERE (T0.price < 100)
```

だとエラーになってしまって、

``` sql
SELECT T0.item_name AS f0 FROM EXAMPLE.item T0 WHERE (T0.price < 100)
```

だとエラーになりません。

また、他のすべての DB は省略してもしなくてもエラーにはならないようです。

参考: http://d.hatena.ne.jp/hhelibex/20110509/1304969768 の(s5)

この変更で doc/examples と relational-query-HDBC-pgTest を実行してみたところ問題なく通りました。
