### PR TITLE
Make english sound more natural in the gh-pages.

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,12 +5,12 @@ title: Project top page
 
 ### What is HRR?
 
-Haskell Relational Record (HRR) is a joined query generator based on typefull relational algebra and a mapper between SQL value list and Haskell record type.
+Haskell Relational Record (HRR) is a query generator based on typed relational algebra and a mapper between SQL value lists and Haskell record types.
 
-- Abstracted - relations are expressed in high level expressions and they are translated into SQL statements. Drivers are provided for DB2, ProsgreSQL, SQLite, MySQL, MicroSoft SQL Server and OracleSQL.
-- Type safe - if HRR code in Haskell is compiled, it is ensured that valid SQL statements are generated. Even placeholders are typed.
-- Composable - relations can be composed to build a bigger relation.
-- Automatic - SQL schema is obtained from a target DB and Haskell recode types are automatically generated at compile time.
+- Abstracted - relations are expressed as high level expressions and they are translated into SQL statements. Drivers are provided for DB2, ProsgreSQL, SQLite, MySQL, MicroSoft SQL Server and OracleSQL.
+- Type safe - SQL statements produced by HRR are guaranteed to be valid if the Haskell code compiles. Even placeholders are typed.
+- Composable - relations can be composed to build bigger relations.
+- Automatic - SQL schema is obtained from a target DB and Haskell types are automatically generated at compile time.
 
 ### Documentations
 
@@ -22,7 +22,7 @@ Haskell Relational Record (HRR) is a joined query generator based on typefull re
 
 ### Questions
 
-If you have any questions and/or suggestions, please record [github issues](https://github.com/khibino/haskell-relational-record/issues).
+If you have any questions and/or suggestions, please submit [github issues](https://github.com/khibino/haskell-relational-record/issues).
 
 ### Authors and contributors
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -8,12 +8,12 @@ title: Quick start
 To start using [Haskell Relational Record](http://khibino.github.io/haskell-relational-record/) (HRR), you need to install:
 
 1. [Glasgow Haskell Compiler](https://www.haskell.org/ghc/) (GHC) + the "cabal" command
-    - We recommend to use [Haskell Platform](https://www.haskell.org/platform/)
+    - We recommend using the [Haskell Platform](https://www.haskell.org/platform/)
 2. The Haskell ["relational-record"](http://hackage.haskell.org/package/relational-record) library
 3. Relational database system
     - In this quickstart, we assume that [SQLite](http://www.sqlite.org/) version 3 has been installed
 
-To install the Haskell "relational-record" library, type as follows:
+To install the Haskell "relational-record" library, run the following commands:
 
     % cabal update
     % cabal install relational-record
@@ -33,21 +33,21 @@ main :: IO ()
 main = putStrLn $ show hello ++ ";"
 {% endhighlight %}
 
-`hello` defines the fist relation. This "SELECT"s a constant tuple value (0,"Hello") from the (virtual) empty table. In other words, this relation just returns (0,"Hello").
+`hello` defines our first relation. This "SELECT"s a constant tuple value (0,"Hello") from the (virtual) empty table. In other words, this relation just returns (0,"Hello").
 
-Let's run this Haskell code to show what kind of SQL statement is generated:
+Let's run the above Haskell code to show what kind of SQL statement is generated:
 
 {% highlight sql %}
 % runghc hello.hs
 SELECT ALL 0 AS f0, 'Hello' AS f1;
 {% endhighlight %}
 
-OK. Next, let's execute this SQL in SQLite:
+OK. Next, let's execute the SQL produced above in SQLite:
 
     % runghc hello.hs | sqlite3 dummy.db
     0|Hello
 
-We got "0\|Hello"! Note that "dummy.db" is really a dummy file.
+We got "0\|Hello"! Note that "dummy.db" is just a dummy file.
 
 ### Composing relations
 
@@ -90,4 +90,4 @@ Finally, let's execute it in SQLite:
 
 Now we understand that relations are composable. Raw SQL does NOT have this feature. Moreover, relations are type safe. If our HRR code can be compiled by GHC, it always generates valid SQL statements.
 
-The next step is to read [HRR tutorial](tutorial.html).
+The next step is to read the [HRR tutorial](tutorial.html).


### PR DESCRIPTION
Fix some of the English in the gh-pages.  I only changed a few small things.

The only thing I wasn't sure about was taking out the word "joined" in the beginning of `index.md`.  It seems okay without "joined".