### PR TITLE
minor grammar/spelling fixes for the web site

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,12 +7,12 @@ title: Project top page
 
 Haskell Relational Record (HRR) is a query generator based on typed relational algebra and a mapper between SQL value lists and Haskell record types.
 
-- Abstracted - relations are expressed as high level expressions and they are translated into SQL statements. Drivers are provided for DB2, ProsgreSQL, SQLite, MySQL, MicroSoft SQL Server and OracleSQL.
-- Type safe - SQL statements produced by HRR are guaranteed to be valid if the Haskell code compiles. Even the type of placeholders are propagated.
+- Abstracted - relations are expressed as high level expressions and they are translated into SQL statements. Drivers are provided for DB2, PostgreSQL, SQLite, MySQL, Microsoft SQL Server and OracleSQL.
+- Type safe - SQL statements produced by HRR are guaranteed to be valid if the Haskell code compiles. Even the types of placeholders are propagated.
 - Composable - relations can be composed to build bigger relations.
 - Automatic - SQL schema is obtained from a target DB and Haskell types are automatically generated at compile time.
 
-### Documentations
+### Documentation
 
 - [Quick start](quickstart.html)
 - [Tutorial](tutorial.html)


### PR DESCRIPTION
Just some minor grammar/spelling mistakes I noticed while checking out your web site.

- I assume ProsgreSQL was supposed to be PostgreSQL
- Microsoft is spelled with a lowercase "s" (see Microsoft.com)
- Documentation is a mass noun
- "type of placeholders are" -- "type" should be plural