### PR TITLE
add ChangeLog.md to relational-query.

### DIFF
--- a/relational-query/ChangeLog.md
+++ b/relational-query/ChangeLog.md
@@ -1,0 +1,7 @@
+
+## 0.5.0.0
+
+- Fix for "invalid single-column insert syntax".
+  https://github.com/khibino/haskell-relational-record/issues/16
+
+- some other things in Database.Relational.Query.Projectable

--- a/relational-query/relational-query.cabal
+++ b/relational-query/relational-query.cabal
@@ -18,6 +18,7 @@ copyright:           Copyright (c) 2013 Kei Hibino
 category:            Database
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  ChangeLog.md
 
 library
   exposed-modules:


### PR DESCRIPTION
I'd like to have ChangeLog for such an important and big package as relational-query.

It's okay not to have histories ages ago, but I'd like to understand changes when you make new releases in future.

Looks like you made some changes in 0.5.0.0 other than fixing #16, but I couldn't exactly figure out what they mean. Perhaps it boils down to "add `like` family functions and change operator signatures", isn't it?