### PR TITLE
Missing mediumint definition for MySQL.

### DIFF
--- a/relational-schemas/src/Database/Relational/Schema/MySQL.hs
+++ b/relational-schemas/src/Database/Relational/Schema/MySQL.hs
@@ -56,6 +56,7 @@ mapFromSqlDefault = fromList
     , ("TIMESTAMP",  [t| POSIXTime |])
     , ("TINYINT",    [t| Int32 |])
     , ("SMALLINT",   [t| Int32 |])
+    , ("MEDIUMINT",  [t| Int32 |])
     , ("INT",        [t| Int32 |])
     , ("INTEGER",    [t| Int32 |])
     , ("BIGINT",     [t| Int64 |])


### PR DESCRIPTION
```
Exception when trying to run compile-time code:
          user error (MySQL: Type mapping is not defined against MySQL type: mediumint)
```