### PR TITLE
sql-words requires base >= 4.5 since it uses Data.Monoid.<>

### DIFF
--- a/sql-words/sql-words.cabal
+++ b/sql-words/sql-words.cabal
@@ -22,14 +22,14 @@ library
   other-modules:
                         Language.SQL.Keyword.Internal.Type
 
-  build-depends:          base <5
+  build-depends:          base >=4.5 && <5
   hs-source-dirs:       src
   ghc-options:          -Wall
 
   default-language:     Haskell2010
 
 test-suite monoids
-  build-depends:         base <5
+  build-depends:         base >=4.5 && <5
                        , quickcheck-simple
                        , QuickCheck >=2
                        , sql-words


### PR DESCRIPTION
[Revised on hackage](https://hackage.haskell.org/package/sql-words-0.1.3.1/revisions/) so there is no need for a new release.

Updated build matrix: http://matrix.hackage.haskell.org/package/sql-words
