### PR TITLE
mysql HDBC example: Follow TH type change

### DIFF
--- a/relational-query-HDBC/example/mysql/example.cabal
+++ b/relational-query-HDBC/example/mysql/example.cabal
@@ -30,8 +30,8 @@ executable example
     , HDBC-mysql >=0.6 && <0.7
     , HDBC-session
     , names-th
-    , relational-query
-    , relational-query-HDBC
+    , relational-query >= 0.7
+    , relational-query-HDBC >= 0.4
     , time
   default-language:
     Haskell2010

--- a/relational-query-HDBC/example/mysql/src/Example/DataSource.hs
+++ b/relational-query-HDBC/example/mysql/src/Example/DataSource.hs
@@ -7,7 +7,7 @@ module Example.DataSource
     where
 
 import Language.Haskell.TH                  (Q, Dec, TypeQ)
-import Language.Haskell.TH.Name.CamelCase   (ConName)
+import Language.Haskell.TH.Syntax           (Name)
 
 import Database.HDBC.Query.TH               (defineTableFromDB)
 import Database.HDBC.Schema.Driver          (typeMap)
@@ -29,5 +29,5 @@ config = defaultMySQLConnectInfo {
 connect :: IO Connection
 connect = connectMySQL config
 
-defineTable :: [(String, TypeQ)] -> String -> String -> [ConName] -> Q [Dec]
+defineTable :: [(String, TypeQ)] -> String -> String -> [Name] -> Q [Dec]
 defineTable tmap = defineTableFromDB connect (driverMySQL { typeMap = tmap })

--- a/relational-query-HDBC/example/mysql/src/Example/DataSource.hs
+++ b/relational-query-HDBC/example/mysql/src/Example/DataSource.hs
@@ -6,17 +6,17 @@ module Example.DataSource
     )
     where
 
-import Language.Haskell.TH                  (Q, Dec, TypeQ)
-import Language.Haskell.TH.Syntax           (Name)
+import Language.Haskell.TH         (Q, Dec, TypeQ)
+import Language.Haskell.TH.Syntax  (Name)
 
-import Database.HDBC.Query.TH               (defineTableFromDB)
-import Database.HDBC.Schema.Driver          (typeMap)
-import Database.HDBC.Schema.MySQL           (driverMySQL)
-import Database.HDBC.MySQL                  ( Connection
-                                            , connectMySQL
-                                            , MySQLConnectInfo(..)
-                                            , defaultMySQLConnectInfo
-                                            )
+import Database.HDBC.Query.TH      (defineTableFromDB)
+import Database.HDBC.Schema.Driver (typeMap)
+import Database.HDBC.Schema.MySQL  (driverMySQL)
+import Database.HDBC.MySQL         ( Connection
+                                   , connectMySQL
+                                   , MySQLConnectInfo(..)
+                                   , defaultMySQLConnectInfo
+                                   )
 
 config :: MySQLConnectInfo
 config = defaultMySQLConnectInfo {


### PR DESCRIPTION
Because ghc complains following error:

```log
Couldn't match type ‘ConName’
                       with ‘Language.Haskell.TH.Syntax.Name’
        Expected type: String -> String -> [ConName] -> Q [Dec]
          Actual type: String
                       -> String -> [Language.Haskell.TH.Syntax.Name] -> Q [Dec]
        In the expression:
          defineTableFromDB connect (driverMySQL {typeMap = tmap})
        In an equation for ‘defineTable’:
            defineTable tmap
              = defineTableFromDB connect (driverMySQL {typeMap = tmap})
```