### PR TITLE
Support for ZonedTime and UTCTime

### DIFF
--- a/relational-query/src/Database/Relational/Query/Pure.hs
+++ b/relational-query/src/Database/Relational/Query/Pure.hs
@@ -29,7 +29,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as LT
 import Text.Printf (PrintfArg, printf)
-import Data.Time (FormatTime, Day, TimeOfDay, LocalTime, formatTime)
+import Data.Time (FormatTime, Day, TimeOfDay, LocalTime, UTCTime, ZonedTime, formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 
 import Language.SQL.Keyword (Keyword (..))

--- a/relational-query/src/Database/Relational/Query/Pure.hs
+++ b/relational-query/src/Database/Relational/Query/Pure.hs
@@ -160,6 +160,14 @@ instance ShowConstantTermsSQL TimeOfDay where
 instance ShowConstantTermsSQL LocalTime where
   showConstantTermsSQL' = constantTimeTerms TIMESTAMP "%Y-%m-%d %H:%M:%S"
 
+-- | Constant SQL terms of 'ZonedTime'.
+instance ShowConstantTermsSQL ZonedTime where
+  showConstantTermsSQL' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
+
+-- | Constant SQL terms of 'ZonedTime'.
+instance ShowConstantTermsSQL UTCTime where
+  showConstantTermsSQL' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
+
 showMaybeTerms :: ShowConstantTermsSQL a => PersistableRecordWidth a -> Maybe a -> [StringSQL]
 showMaybeTerms wa = d  where
   d (Just a) = showConstantTermsSQL' a

--- a/sql-words/src/Language/SQL/Keyword/Internal/Type.hs
+++ b/sql-words/src/Language/SQL/Keyword/Internal/Type.hs
@@ -91,7 +91,7 @@ data Keyword = SELECT | ALL | DISTINCT | ON
 
              | IS | NULL | IN
 
-             | DATE | TIME | TIMESTAMP | INTERVAL
+             | DATE | TIME | TIMESTAMP | TIMESTAMPTZ | INTERVAL
 
              | Sequence !DString
              deriving (Read, Show)


### PR DESCRIPTION
This PR adds the TIMEZONETZ keyword and adds appropriate instances for haskell time types ZonedTime and UTCTime. 