### PR TITLE
For persistent-relational-record

### DIFF
--- a/persistable-record/src/Database/Record/TH.hs
+++ b/persistable-record/src/Database/Record/TH.hs
@@ -40,6 +40,7 @@ module Database.Record.TH (
   makeRecordPersistableWithSqlTypeFromDefined,
   makeRecordPersistableWithSqlTypeDefaultFromDefined,
   defineColumnOffsets,
+  defineColumnOffsets',
 
   recordWidthTemplate,
 
@@ -204,13 +205,20 @@ recordWidthTemplate ty =
 defineColumnOffsets :: ConName -- ^ Record type constructor.
                     -> [TypeQ] -- ^ Types of record columns.
                     -> Q [Dec] -- ^ Declaration of 'PersistableWidth' instance.
-defineColumnOffsets typeName' tys = do
-  let ofsVar = columnOffsetsVarNameDefault $ conName typeName'
+defineColumnOffsets typeName' =
+  defineColumnOffsets' (conName typeName') (toTypeCon typeName')
+
+defineColumnOffsets' :: Name -- ^ Record type name
+                     -> TypeQ -- ^ Record type
+                     -> [TypeQ] -- ^ Types of record columns.
+                     -> Q [Dec] -- ^ Declaration of 'PersistableWidth' instance.
+defineColumnOffsets' name recType tys = do
+  let ofsVar = columnOffsetsVarNameDefault name
       widthIxE = integralE $ length tys
   ar <- simpleValD (varName ofsVar) [t| Array Int Int |]
         [| listArray (0 :: Int, $widthIxE) $
            scanl (+) (0 :: Int) $(listE $ map recordWidthTemplate tys) |]
-  pw <- [d| instance PersistableWidth $(toTypeCon typeName') where
+  pw <- [d| instance PersistableWidth $recType where
               persistableWidth = unsafePersistableRecordWidth $ $(toVarExp ofsVar) ! $widthIxE
           |]
   return $ ar ++ pw

--- a/relational-query/src/Database/Relational/Query/TH.hs
+++ b/relational-query/src/Database/Relational/Query/TH.hs
@@ -44,6 +44,7 @@ module Database.Relational.Query.TH (
 
   -- * Table metadata type and basic 'Relation'
   defineTableTypes, defineTableTypesWithConfig, defineTableTypesDefault,
+  defineTableDerivableInstance, defineTableDerivations,
 
   -- * Basic SQL templates generate rules
   definePrimaryQuery,


### PR DESCRIPTION
persistent-relational-record needs to generate instances such as `TableDerivable (Entity SomeRecord)`.
