### PR TITLE
use column_type instead of data_type for determining MySQL -> Haskell…

### DIFF
--- a/relational-query-HDBC/src/Database/HDBC/Schema/MySQL.hs
+++ b/relational-query-HDBC/src/Database/HDBC/Schema/MySQL.hs
@@ -22,6 +22,7 @@ import           Control.Applicative                ((<$>), (<|>))
 import           Control.Monad                      (guard)
 import           Control.Monad.Trans.Class          (lift)
 import           Control.Monad.Trans.Maybe          (MaybeT)
+import           Data.Char                          (toUpper)
 import qualified Data.List                          as List
 import           Data.Map                           (fromList)
 
@@ -97,7 +98,7 @@ getColumns' tmap conn lchan scm tbl = maybeIO ([], []) id $ do
             hoistMaybe (getType (fromList tmap) col) <|>
             compileError lchan
             ("Type mapping is not defined against MySQL type: "
-             ++ Columns.dataType col)
+             ++ (map toUpper (Columns.columnType col)))
 
 -- | Driver implementation
 driverMySQL :: IConnection conn => Driver conn

--- a/relational-schemas/src/Database/Relational/Schema/MySQL.hs
+++ b/relational-schemas/src/Database/Relational/Schema/MySQL.hs
@@ -79,7 +79,7 @@ getType mapFromSql rec = do
            Map.lookup key mapFromSqlDefault
     return (normalizeColumn $ Columns.columnName rec, mayNull typ)
     where
-        key = map toUpper $ Columns.dataType rec
+        key = map toUpper $ Columns.columnType rec
         mayNull typ = if notNull rec
                       then typ
                       else [t|Maybe $(typ)|]

--- a/relational-schemas/src/Database/Relational/Schema/MySQLInfo/Columns.hs
+++ b/relational-schemas/src/Database/Relational/Schema/MySQLInfo/Columns.hs
@@ -18,5 +18,6 @@ $(defineTableTypesAndRecord config
     , ("column_default",    [t|Maybe String|])
     , ("is_nullable",       [t|String|])
     , ("data_type",         [t|String|])
+    , ("column_type",       [t|String|])
     ]
     [''Show])


### PR DESCRIPTION
… type mapping

This is not meant to be a serious pull request. It is meant to show how could implement #41. With these changes you can use a type map like:

```
ourTypeMap =
    [ ("CHAR",       [t| Text |])
    , ("VARCHAR",    [t| Text |])
    , ("VARCHAR(255)",    [t| Text |])
    , ("TINYTEXT",   [t| Text |])
    , ("TEXT",       [t| Text |])
    , ("MEDIUMTEXT", [t| Text |])
    , ("LONGTEXT",   [t| Text |])
    , ("TINYBLOB",   [t| ByteString |])
    , ("BLOB",       [t| ByteString |])
    , ("MEDIUMBLOB", [t| ByteString |])
    , ("LONGBLOB",   [t| ByteString |])
    , ("DATE",       [t| Day |])
    , ("DATETIME",   [t| LocalTime |])
    , ("TIME",       [t| TimeOfDay |])
    , ("TIMESTAMP",  [t| POSIXTime |])
    , ("TINYINT(1)", [t| Bool |])
    , ("TINYINT(4)", [t| Bool |])
    , ("TINYINT(3) UNSIGNED", [t| Int8 |])
    , ("TINYINT",    [t| Int8 |])
    , ("SMALLINT",   [t| Int16 |])
    , ("SMALLINT(5) UNSIGNED", [t| Int16 |])
    , ("SMALLINT(6)", [t| Int16 |])
    , ("MEDIUMINT",  [t| Int32 |])
    , ("INT",        [t| Int32 |])
    , ("INT(10) UNSIGNED",    [t| Int32 |])
    , ("INT(11)",    [t| Int32 |])
    , ("INT(255)",    [t| Int32 |])
    , ("INTEGER",    [t| Int32 |])
    , ("BIGINT",     [t| Int64 |])

    , ("DECIMAL(3,1)",     [t| Double |])
    , ("DECIMAL(14,6)",     [t| Double |])
    , ("DECIMAL(8,4)",     [t| Double |])
    , ("DECIMAL(9,5)",     [t| Double |])
    , ("DECIMAL(12,4)",     [t| Double |])
    ]
```

Which might be bad because you have to enumerate every column_type, but at least it lets you specify my use case of turning tinyint(1) into Bool. It might be okay to carefully select the type for every possible variation you use too; I'm not sure.

This is meant to be a prototype showing how we can use column_type
instead of data_type to determine what type a particular column should
have. This allows mappings like tinyint(1) -> Bool without mapping
tinyint(3) to Bool, for example.

Probably this implementation is bad because it will break existing code,
so a more clean transition path should probably be investigated.