### PR TITLE
identifier quotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ cabal.sandbox.config
 *.aux
 *.hp
 /.stack-work/
+.idea/
+*.iml

--- a/relational-query/src/Database/Relational/Query.hs
+++ b/relational-query/src/Database/Relational/Query.hs
@@ -50,7 +50,7 @@ import Database.Relational.Query.Constraint
    Primary, Unique, NotNull)
 import Database.Relational.Query.Context
 import Database.Relational.Query.Component
-  (NameConfig (..), SchemaNameMode (..), Config (..), defaultConfig, ProductUnitSupport (..), Order (..))
+  (NameConfig (..), SchemaNameMode (..), Config (..), defaultConfig, ProductUnitSupport (..), IdentifierQuotation (..), Order (..))
 import Database.Relational.Query.Sub (SubQuery, unitSQL, queryWidth)
 import Database.Relational.Query.Projection (Projection, list)
 import Database.Relational.Query.Projectable

--- a/relational-query/src/Database/Relational/Query/Component.hs
+++ b/relational-query/src/Database/Relational/Query/Component.hs
@@ -24,9 +24,10 @@ module Database.Relational.Query.Component
                 , schemaNameMode
                 , normalizedTableName
                 , verboseAsCompilerWarning
-                , nameConfig),
+                , nameConfig
+                , identifierQuotation),
          defaultConfig,
-         ProductUnitSupport (..), Duplication (..),
+         ProductUnitSupport (..), Duplication (..), IdentifierQuotation (..),
 
          -- * Duplication attribute
          showsDuplication,
@@ -118,6 +119,7 @@ data Config =
   , normalizedTableName       ::  !Bool
   , verboseAsCompilerWarning  ::  !Bool
   , nameConfig                ::  !NameConfig
+  , identifierQuotation       ::  !IdentifierQuotation
   } deriving Show
 
 -- | Default configuration.
@@ -131,11 +133,14 @@ defaultConfig =
          , nameConfig                =  NameConfig { recordConfig     =  RecordTH.defaultNameConfig
                                                    , relationVarName  =  const varCamelcaseName
                                                    }
+         , identifierQuotation       =  NoQuotation
          }
 
 -- | Unit of product is supported or not.
 data ProductUnitSupport = PUSupported | PUNotSupported  deriving Show
 
+-- | Configuration for quotation of identifiers of SQL.
+data IdentifierQuotation = NoQuotation | Quotation Char deriving Show
 
 -- | Result record duplication attribute
 data Duplication = All | Distinct  deriving Show

--- a/relational-query/src/Database/Relational/Query/TH.hs
+++ b/relational-query/src/Database/Relational/Query/TH.hs
@@ -274,9 +274,9 @@ tableSQL normalize snm iq schema table = case snm of
     qt = quote iq
 
 quote :: IdentifierQuotation -> String -> String
-quote NoQuotation    s = s
-quote (Quotation qc) s = qc : s ++ qc : []
-  where escape q = join . (fmap (\c -> if c == q then [q, q] else [c]))
+quote NoQuotation   s = s
+quote (Quotation q) s = q : (escape s) ++ q : []
+  where escape = join . (fmap (\c -> if c == q then [q, q] else [c]))
 
 derivationVarNameDefault :: String -> VarName
 derivationVarNameDefault =  (`varNameWithPrefix` "derivationFrom")

--- a/relational-query/src/Database/Relational/Query/TH.hs
+++ b/relational-query/src/Database/Relational/Query/TH.hs
@@ -270,9 +270,11 @@ tableSQL normalize snm iq schema table = case snm of
     normalizeT
       | normalize = map toLower table
       | otherwise = table
-    qt s = case iq of
-             NoQuotation -> s
-             Quotation qc -> qc : s ++ qc : [] -- TODO: Escaping.
+    qt = quote iq
+
+quote :: IdentifierQuotation -> String -> String
+quote NoQuotation    s = s
+quote (Quotation qc) s = qc : s ++ qc : [] -- TODO: Escaping.
 
 derivationVarNameDefault :: String -> VarName
 derivationVarNameDefault =  (`varNameWithPrefix` "derivationFrom")
@@ -336,7 +338,7 @@ defineTableTypesWithConfig config schema table columns = do
              (table `varNameWithPrefix` "insertQuery")
              (recordType recConfig schema table)
              (tableSQL (normalizedTableName config) (schemaNameMode config) (identifierQuotation config) schema table)
-             (map (fst . fst) columns)
+             (map ((quote (identifierQuotation config)) . fst . fst) columns)
   colsDs <- defineColumnsDefault (recordTypeName recConfig schema table) columns
   return $ tableDs ++ colsDs
 

--- a/relational-query/src/Database/Relational/Query/TH.hs
+++ b/relational-query/src/Database/Relational/Query/TH.hs
@@ -67,6 +67,7 @@ module Database.Relational.Query.TH (
   reifyRelation,
   ) where
 
+import Control.Monad (join)
 import Data.Char (toUpper, toLower)
 import Data.List (foldl1')
 import Data.Array.IArray ((!))
@@ -274,7 +275,8 @@ tableSQL normalize snm iq schema table = case snm of
 
 quote :: IdentifierQuotation -> String -> String
 quote NoQuotation    s = s
-quote (Quotation qc) s = qc : s ++ qc : [] -- TODO: Escaping.
+quote (Quotation qc) s = qc : s ++ qc : []
+  where escape q = join . (fmap (\c -> if c == q then [q, q] else [c]))
 
 derivationVarNameDefault :: String -> VarName
 derivationVarNameDefault =  (`varNameWithPrefix` "derivationFrom")


### PR DESCRIPTION
# Why?

I want to use identifiers which are keywords or which have signs. So I need to quote identifiers.

# Features

- [x] Configuration about identifier quotation (quoting or not, which character to use)
- Quoting identifiers
  - [x] schema and table
  - [x] column
- [x] Escaping