### PR TITLE
Export record labels and constructor of Database.Record.TH.NameConfig

### DIFF
--- a/persistable-record/src/Database/Record/TH.hs
+++ b/persistable-record/src/Database/Record/TH.hs
@@ -52,7 +52,7 @@ module Database.Record.TH (
   reifyRecordType,
 
   -- * Templates about record type name
-  NameConfig,  defaultNameConfig,
+  NameConfig(..),  defaultNameConfig,
 
   recordTypeName, recordType,
 


### PR DESCRIPTION
This change makes it possible to customize `NameConfig` from the default.