### PR TITLE
Ignore stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 /.stack-work/
 .idea/
 *.iml
+stack.yaml


### PR DESCRIPTION
We shouldn't add stack.yaml to this repository to keep `stack/stack.yaml.example` just an "example".