### PR TITLE
:memo: Modify documents of configuration types

### DIFF
--- a/persistable-record/src/Database/Record/TH.hs
+++ b/persistable-record/src/Database/Record/TH.hs
@@ -92,15 +92,17 @@ instance Show NameConfig where
   show = const "<nameConfig>"
 
 -- | Default implementation of 'NameConfig' type.
---   To change how the generated record type and its columns are named,
+--   To change how generated record types and their columns are named,
 --   use record update syntax:
 --
--- > defaultNameConfig
--- >   { recordTypeName = \schema table -> varCamelcaseName $ schema ++ "_" ++ table
--- >     ^ append the table name after the schema name. e.g. "schemaTable"
--- >   , columnName = \table column -> varCamelcaseName $ table ++ "_" ++ column
--- >     ^ append the column name after the table name. e.g. "tableColumn"
--- >   }
+-- @
+--   defaultNameConfig
+--     { recordTypeName = \\schema table -> 'varCamelcaseName' $ schema ++ "_" ++ table
+--     -- ^ append the table name after the schema name. e.g. "SchemaTable"
+--     , columnName = \\table column -> 'varCamelcaseName' $ table ++ "_" ++ column
+--     -- ^ append the column name after the table name. e.g. "tableColumn"
+--     }
+-- @
 defaultNameConfig :: NameConfig
 defaultNameConfig =
   NameConfig

--- a/relational-query/src/Database/Relational/Config.hs
+++ b/relational-query/src/Database/Relational/Config.hs
@@ -16,4 +16,4 @@ module Database.Relational.Config
 import Database.Relational.Internal.Config
   (NameConfig (..),
    ProductUnitSupport (..), SchemaNameMode (..), IdentifierQuotation (..),
-   Config (..), defaultConfig,)
+   Config (..), defaultConfig, defaultNameConfig)


### PR DESCRIPTION
- Add references to related data constructors and functions in the samples.
- Display each label of `Config`
- Reorder the documents of functions in `Database.Relational.Config`
  to show how the configuration should be customized first of all.
- Add document of some of the record label of `Database.Relational.Config`.
- Split out and export the default value of `Database.Relational.Config.nameConfig`.