### PR TITLE
Ignore all stack-work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
-/.stack-work/
+.stack-work/
 .idea/
 *.iml
 stack.yaml


### PR DESCRIPTION
`.stack-work` is actually created in all subdirectories