### PR TITLE
Hide non-standard TIMESTAMPTZ instances from other DBs

### DIFF
--- a/relational-query/relational-query.cabal
+++ b/relational-query/relational-query.cabal
@@ -35,6 +35,7 @@ library
                        Database.Relational.Table
                        Database.Relational.SimpleSql
                        Database.Relational.Pure
+                       Database.Relational.Pure.NonStandard.TIMESTAMPTZ
                        Database.Relational.Pi
                        Database.Relational.Pi.Unsafe
                        Database.Relational.Constraint
@@ -80,6 +81,7 @@ library
                        Database.Relational.Internal.Config
                        Database.Relational.Internal.String
                        Database.Relational.Internal.UntypedTable
+                       Database.Relational.Pure.Internal
                        Database.Relational.SqlSyntax.Types
                        Database.Relational.SqlSyntax.Join
                        Database.Relational.SqlSyntax.Aggregate

--- a/relational-query/src/Database/Relational/Pure.hs
+++ b/relational-query/src/Database/Relational/Pure.hs
@@ -26,7 +26,7 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import Text.Printf (PrintfArg, printf)
-import Data.Time (FormatTime, Day, TimeOfDay, LocalTime, UTCTime, ZonedTime, formatTime)
+import Data.Time (FormatTime, Day, TimeOfDay, LocalTime, formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.DList (DList, fromList)
 
@@ -39,25 +39,7 @@ import Database.Record.Persistable
 import Database.Relational.Internal.String (StringSQL, stringSQL, boolSQL)
 
 import Database.Relational.ProjectableClass (LiteralSQL (..))
-
-
--- | Constant integral SQL terms.
-intTermsSQL :: (Show a, Integral a) => a -> DList StringSQL
-intTermsSQL =  pure . stringSQL . show
-
--- | Escape 'String' for constant SQL string expression.
-escapeStringToSqlExpr :: String -> String
-escapeStringToSqlExpr =  rec  where
-  rec ""        = ""
-  rec ('\'':cs) = '\'' : '\'' : rec cs
-  rec (c:cs)    = c : rec cs
-
--- | From 'String' into constant SQL string expression.
-stringExprSQL :: String -> StringSQL
-stringExprSQL =  stringSQL . ('\'':) . (++ "'") . escapeStringToSqlExpr
-
-stringTermsSQL :: String -> DList StringSQL
-stringTermsSQL = pure . stringExprSQL
+import Database.Relational.Pure.Internal (intTermsSQL, stringTermsSQL, stringExprSQL)
 
 -- | Constant SQL terms of '()'.
 instance LiteralSQL ()
@@ -163,16 +145,6 @@ instance LiteralSQL TimeOfDay where
 -- | Constant SQL terms of 'LocalTime'.
 instance LiteralSQL LocalTime where
   showLiteral' = constantTimeTerms TIMESTAMP "%Y-%m-%d %H:%M:%S"
-
--- | Constant SQL terms of 'ZonedTime'.
---   This generates ***NOT STANDARD*** SQL of TIMESTAMPTZ literal.
-instance LiteralSQL ZonedTime where
-  showLiteral' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
-
--- | Constant SQL terms of 'UTCTime'.
---   This generates ***NOT STANDARD*** SQL of TIMESTAMPTZ literal with UTC timezone.
-instance LiteralSQL UTCTime where
-  showLiteral' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
 
 showMaybeTerms :: LiteralSQL a => PersistableRecordWidth a -> Maybe a -> DList StringSQL
 showMaybeTerms wa = d  where

--- a/relational-query/src/Database/Relational/Pure/Internal.hs
+++ b/relational-query/src/Database/Relational/Pure/Internal.hs
@@ -1,0 +1,37 @@
+module Database.Relational.Pure.Internal
+    ( intTermsSQL
+    , escapeStringToSqlExpr
+    , stringExprSQL
+    , stringTermsSQL
+    , constantTimeTerms
+    ) where
+
+import Control.Applicative (pure)
+import Data.DList (DList)
+import Data.Monoid ((<>))
+import Data.Time (FormatTime, formatTime)
+import Data.Time.Locale.Compat (defaultTimeLocale)
+import Database.Relational.Internal.String (StringSQL, stringSQL)
+import Language.SQL.Keyword (Keyword (..))
+
+-- | Constant integral SQL terms.
+intTermsSQL :: (Show a, Integral a) => a -> DList StringSQL
+intTermsSQL = pure . stringSQL . show
+
+-- | Escape 'String' for constant SQL string expression.
+escapeStringToSqlExpr :: String -> String
+escapeStringToSqlExpr = rec where
+  rec ""        = ""
+  rec ('\'':cs) = '\'' : '\'' : rec cs
+  rec (c:cs)    = c : rec cs
+
+-- | From 'String' into constant SQL string expression.
+stringExprSQL :: String -> StringSQL
+stringExprSQL = stringSQL . ('\'' :) . (++ "'") . escapeStringToSqlExpr
+
+stringTermsSQL :: String -> DList StringSQL
+stringTermsSQL = pure . stringExprSQL
+
+constantTimeTerms :: FormatTime t => Keyword -> String -> t -> DList StringSQL
+constantTimeTerms kw fmt t =
+    pure $ kw <> stringExprSQL (formatTime defaultTimeLocale fmt t)

--- a/relational-query/src/Database/Relational/Pure/NonStandard/TIMESTAMPTZ.hs
+++ b/relational-query/src/Database/Relational/Pure/NonStandard/TIMESTAMPTZ.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Database.Relational.Pure.NonStandard.TIMESTAMPTZ () where
+
+import Data.Time (UTCTime, ZonedTime)
+import Database.Relational.ProjectableClass (LiteralSQL (..))
+import Database.Relational.Pure.Internal (constantTimeTerms)
+import Language.SQL.Keyword (Keyword (..))
+
+-- | Constant SQL terms of 'ZonedTime'.
+--   This generates ***NOT STANDARD*** SQL of TIMESTAMPTZ literal.
+instance LiteralSQL ZonedTime where
+  showLiteral' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
+
+-- | Constant SQL terms of 'UTCTime'.
+--   This generates ***NOT STANDARD*** SQL of TIMESTAMPTZ literal with UTC timezone.
+instance LiteralSQL UTCTime where
+  showLiteral' = constantTimeTerms TIMESTAMPTZ "%Y-%m-%d %H:%M:%S%z"
+

--- a/relational-schemas/src/Database/Relational/Schema/PostgreSQL.hs
+++ b/relational-schemas/src/Database/Relational/Schema/PostgreSQL.hs
@@ -39,6 +39,8 @@ import Database.Relational
    wheres, (.=.), (.>.), in', values, (!), fst', snd',
    placeholder, asc, value, unsafeProjectSql, (><))
 
+import Database.Relational.Pure.NonStandard.TIMESTAMPTZ ()
+
 import Database.Relational.Schema.PgCatalog.PgNamespace (pgNamespace)
 import qualified Database.Relational.Schema.PgCatalog.PgNamespace as Namespace
 import Database.Relational.Schema.PgCatalog.PgClass (pgClass)


### PR DESCRIPTION
`UTCTime` and `ZonedTime` instances implemented with `TIMESTAMPTZ` literal should not work on other databases, in addition, those instances will hamper users who intend to implement own intsances (at on their risks).

This PR moves those instances to `Database.Relational.Pure.NonStandard.TIMESTAMPTZ` and avoid import by default.

This PR will break user's existing codes, but most users who use relational-schemas to import the DB schema should not affected.