### PR TITLE
(WIP) (RFC) Safer placeholders

### DIFF
--- a/relational-query-HDBC/src/Database/HDBC/Record/Statement.hs
+++ b/relational-query-HDBC/src/Database/HDBC/Record/Statement.hs
@@ -31,7 +31,10 @@ module Database.HDBC.Record.Statement (
   ) where
 
 import Control.Exception (bracket)
-import Database.Relational (UntypeableNoFetch (untypeNoFetch))
+import Database.Relational
+  (UntypeableNoFetch (untypeNoFetch),
+   sortByPlaceholderOffsets,
+   WithPlaceholderOffsets (WithPlaceholderOffsets), SQLWithPlaceholderOffsets, detachPlaceholderOffsets, placeholderOffsets)
 import Database.HDBC (IConnection, Statement, SqlValue)
 import qualified Database.HDBC as HDBC
 
@@ -41,8 +44,8 @@ import Database.Record (ToSql, fromRecord)
 newtype PreparedStatement p a =
   PreparedStatement {
     -- | Untyped prepared statement before executed.
-    prepared :: Statement
-    }
+    prepared :: WithPlaceholderOffsets Statement
+  }
 
 -- | Typed prepared statement which has bound placeholder parameters.
 data BoundStatement a =
@@ -64,15 +67,18 @@ data ExecutedStatement a =
   }
 
 -- | Unsafely untype prepared statement.
-untypePrepared :: PreparedStatement p a -> Statement
+untypePrepared :: PreparedStatement p a -> WithPlaceholderOffsets Statement
 untypePrepared =  prepared
 
 -- | Run prepare and unsafely make Typed prepared statement.
 unsafePrepare :: IConnection conn
               => conn                       -- ^ Database connection
-              -> String                     -- ^ Raw SQL String
+              -> SQLWithPlaceholderOffsets  -- ^ Raw SQL String
               -> IO (PreparedStatement p a) -- ^ Result typed prepared query with parameter type 'p' and result type 'a'
-unsafePrepare conn = fmap PreparedStatement . HDBC.prepare conn
+unsafePrepare conn sps =
+  fmap (PreparedStatement . WithPlaceholderOffsets (placeholderOffsets sps))
+    . HDBC.prepare conn
+    $ detachPlaceholderOffsets sps
 
 -- | Generalized prepare inferred from 'UntypeableNoFetch' instance.
 prepareNoFetch :: (UntypeableNoFetch s, IConnection conn)
@@ -85,15 +91,15 @@ prepareNoFetch conn = unsafePrepare conn . untypeNoFetch
 --   PreparedStatement is released on closing connection,
 --   so connection pooling cases often cause resource leaks.
 finish :: PreparedStatement p a -> IO ()
-finish = HDBC.finish . prepared
+finish = HDBC.finish . detachPlaceholderOffsets . prepared
 
 -- | Bracketed prepare operation.
 --   Unsafely make Typed prepared statement.
 --   PreparedStatement is released on closing connection,
 --   so connection pooling cases often cause resource leaks.
 withUnsafePrepare :: IConnection conn
-                  => conn   -- ^ Database connection
-                  -> String -- ^ Raw SQL String
+                  => conn                      -- ^ Database connection
+                  -> SQLWithPlaceholderOffsets -- ^ Raw SQL String
                   -> (PreparedStatement p a -> IO b)
                   -> IO b
 withUnsafePrepare conn qs =
@@ -114,7 +120,11 @@ bind :: ToSql SqlValue p
      => PreparedStatement p a -- ^ Prepared query to bind to
      -> p                     -- ^ Parameter to bind
      -> BoundStatement a      -- ^ Result parameter bound statement
-bind q p = BoundStatement { bound = prepared q, params = fromRecord p }
+bind q p = BoundStatement { bound = st, params = sortByPlaceholderOffsets phs $ fromRecord p }
+ where
+  stphs = untypePrepared q
+  st = detachPlaceholderOffsets stphs
+  phs = placeholderOffsets stphs
 
 -- | Same as 'bind' except for argument is flipped.
 bindTo :: ToSql SqlValue p => p -> PreparedStatement p a -> BoundStatement a

--- a/relational-query/relational-query.cabal
+++ b/relational-query/relational-query.cabal
@@ -61,9 +61,12 @@ library
                        Database.Relational.Monad.Simple
                        Database.Relational.Monad.Aggregate
                        Database.Relational.Monad.Unique
+                       Database.Relational.Monad.ReferPlaceholders
                        Database.Relational.Monad.Restrict
                        Database.Relational.Monad.Assign
                        Database.Relational.Monad.Register
+                       Database.Relational.Monad.Trans.JoinState
+                       Database.Relational.Monad.Trans.Qualify
                        Database.Relational.Relation
                        Database.Relational.Set
                        Database.Relational.Sequence
@@ -89,8 +92,6 @@ library
                        Database.Relational.SqlSyntax.Query
                        Database.Relational.SqlSyntax.Fold
                        Database.Relational.SqlSyntax.Updates
-                       Database.Relational.Monad.Trans.JoinState
-                       Database.Relational.Monad.Trans.Qualify
                        Database.Relational.InternalTH.Base
 
                        -- for GHC version equal or more than 8.0

--- a/relational-query/relational-query.cabal
+++ b/relational-query/relational-query.cabal
@@ -56,6 +56,7 @@ library
                        Database.Relational.Monad.Trans.Join
                        Database.Relational.Monad.Trans.Config
                        Database.Relational.Monad.Trans.Assigning
+                       Database.Relational.Monad.Trans.ReferredPlaceholders
                        Database.Relational.Monad.Type
                        Database.Relational.Monad.Simple
                        Database.Relational.Monad.Aggregate

--- a/relational-query/src/Database/Relational.hs
+++ b/relational-query/src/Database/Relational.hs
@@ -67,6 +67,7 @@ import Database.Relational.Monad.Class
    MonadAggregate, groupBy, groupBy',
    MonadQuery, query', queryMaybe',
    MonadPartition, partitionBy,
+   MonadReferPlaceholders,
    distinct, all', on)
 import Database.Relational.Monad.Trans.Ordering
   (Orderings, orderBy', orderBy, asc, desc)

--- a/relational-query/src/Database/Relational.hs
+++ b/relational-query/src/Database/Relational.hs
@@ -55,7 +55,7 @@ import Database.Relational.Context
 import Database.Relational.Config
 import Database.Relational.SqlSyntax
   (Order (..), Nulls (..), AggregateKey, Record, Predicate, PI,
-   SubQuery, unitSQL, queryWidth, )
+   SubQuery, PlaceholderOffsets, sortByPlaceholderOffsets, unitSQL, queryWidth, )
 import Database.Relational.Record (RecordList, list)
 import Database.Relational.ProjectableClass
 import Database.Relational.Projectable

--- a/relational-query/src/Database/Relational.hs
+++ b/relational-query/src/Database/Relational.hs
@@ -22,12 +22,12 @@ module Database.Relational (
   module Database.Relational.TupleInstances,
   module Database.Relational.Monad.BaseType,
   module Database.Relational.Monad.Class,
-  module Database.Relational.Monad.Trans.Ordering,
   module Database.Relational.Monad.Trans.Aggregating,
-  module Database.Relational.Monad.Trans.Assigning,
+  module Database.Relational.Monad.Trans.ReferredPlaceholders,
   module Database.Relational.Monad.Type,
   module Database.Relational.Monad.Simple,
   module Database.Relational.Monad.Aggregate,
+  module Database.Relational.Monad.ReferPlaceholders,
   module Database.Relational.Monad.Restrict,
   module Database.Relational.Monad.Unique,
   module Database.Relational.Monad.Assign,
@@ -63,17 +63,21 @@ import Database.Relational.TupleInstances
 import Database.Relational.Monad.BaseType
 import Database.Relational.Monad.Class
   (MonadQualify,
-   MonadRestrict, wheres, having, restrict,
-   MonadAggregate, groupBy, groupBy',
-   MonadQuery, query', queryMaybe',
-   MonadPartition, partitionBy,
-   MonadReferPlaceholders,
-   distinct, all', on)
-import Database.Relational.Monad.Trans.Ordering
-  (Orderings, orderBy', orderBy, asc, desc)
+   MonadRestrict,
+   MonadAggregate,
+   MonadQuery,
+   MonadPartition,
+   distinct, all',)
 import Database.Relational.Monad.Trans.Aggregating
   (key, key', set, bkey, rollup, cube, groupingSets)
-import Database.Relational.Monad.Trans.Assigning (assignTo, (<-#))
+import Database.Relational.Monad.Trans.ReferredPlaceholders
+import Database.Relational.Monad.ReferPlaceholders
+  (wheres, having,
+   groupBy, groupBy',
+   partitionBy, on,
+   query', queryMaybe',
+   orderBy', orderBy, asc, desc,
+   assignTo, (<-#),)
 import Database.Relational.Monad.Type
 import Database.Relational.Monad.Simple (QuerySimple, SimpleQuery)
 import Database.Relational.Monad.Aggregate

--- a/relational-query/src/Database/Relational/Arrow.hs
+++ b/relational-query/src/Database/Relational/Arrow.hs
@@ -226,40 +226,40 @@ queryListU' :: MonadQualify ConfigureQuery m
            -> QueryA m () (PlaceHolders p, RecordList (Record c) r)
 queryListU' r = unsafeQueryList' $ \() -> r
 
-unsafeQueryScalar :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+unsafeQueryScalar :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
                   => (a -> UniqueRelation () c r)
                   -> QueryA m a (Record c (Maybe r))
 unsafeQueryScalar rf = queryA $ Monadic.queryScalar . rf
 
-unsafeQueryScalar' :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+unsafeQueryScalar' :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
                    => (a -> UniqueRelation p c r)
                    -> QueryA m a (PlaceHolders p, Record c (Maybe r))
 unsafeQueryScalar' rf = queryA $ Monadic.queryScalar' . rf
 
 -- | Same as 'Monadic.queryScalar'. Arrow version.
 --   The result arrow is designed to be injected by any local projected record.
-queryScalar :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+queryScalar :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
             => (Record c a -> UniqueRelation () c r)
             -> QueryA m (Record c a) (Record c (Maybe r))
 queryScalar = unsafeQueryScalar
 
 -- | Same as 'Monadic.queryScalar''. Arrow version.
 --   The result arrow is designed to be injected by any local projected record.
-queryScalar' :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+queryScalar' :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
              => (Record c a -> UniqueRelation p c r)
              -> QueryA m (Record c a) (PlaceHolders p, Record c (Maybe r))
 queryScalar' = unsafeQueryScalar'
 
 -- | Same as 'Monadic.queryScalar'. Arrow version.
 --   Useful for no reference cases to local projected records.
-queryScalarU :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+queryScalarU :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
             => UniqueRelation () c r
             -> QueryA m () (Record c (Maybe r))
 queryScalarU r = unsafeQueryScalar $ \() -> r
 
 -- | Same as 'Monadic.queryScalar''. Arrow version.
 --   Useful for no reference cases to local projected records.
-queryScalarU' :: (MonadQualify ConfigureQuery m, ScalarDegree r)
+queryScalarU' :: (MonadQualify ConfigureQuery m, Monadic.MonadReferPlaceholders m, ScalarDegree r)
              => UniqueRelation p c r
              -> QueryA m () (PlaceHolders p, Record c (Maybe r))
 queryScalarU' r = unsafeQueryScalar' $ \() -> r

--- a/relational-query/src/Database/Relational/Derives.hs
+++ b/relational-query/src/Database/Relational/Derives.hs
@@ -40,8 +40,8 @@ import Database.Relational.Table (Table, TableDerivable)
 import Database.Relational.Pi.Unsafe (Pi, unsafeExpandIndexes)
 import qualified Database.Relational.Record as Record
 import Database.Relational.Projectable (placeholder, (.=.), (!))
-import Database.Relational.Monad.Class (wheres)
 import Database.Relational.Monad.BaseType (Relation, relationWidth)
+import Database.Relational.Monad.ReferPlaceholders (wheres)
 import Database.Relational.Relation
   (derivedRelation, relation, relation', query, UniqueRelation, unsafeUnique)
 import Database.Relational.Constraint

--- a/relational-query/src/Database/Relational/Monad/Aggregate.hs
+++ b/relational-query/src/Database/Relational/Monad/Aggregate.hs
@@ -36,7 +36,7 @@ import Database.Relational.Internal.ContextType (Flat, Aggregated, OverWindow)
 import Database.Relational.SqlSyntax
   (Duplication, Record, SubQuery, Predicate, JoinProduct,
    OrderingTerm, composeOrderBy, aggregatedSubQuery,
-   AggregateColumnRef, AggregateElem, composePartitionBy, )
+   AggregateColumnRef, AggregateElem, composePartitionBy, placeholderOffsets, )
 import qualified Database.Relational.SqlSyntax as Syntax
 
 import qualified Database.Relational.Record as Record
@@ -96,6 +96,7 @@ over :: SqlContext c
      -> Record c a
 wp `over` win =
   Record.unsafeFromSqlTerms
+  (placeholderOffsets wp)
   [ c <> OVER <> SQL.paren (composePartitionBy pt <> composeOrderBy ot)
   | c <- Record.columns wp
   ]  where (((), ot), pt) = extractWindow win

--- a/relational-query/src/Database/Relational/Monad/Aggregate.hs
+++ b/relational-query/src/Database/Relational/Monad/Aggregate.hs
@@ -65,7 +65,7 @@ type Window           c = ReferredPlaceholders (Orderings c (PartitioningSet c))
 
 -- | Restricted 'MonadRestrict' instance.
 instance MonadRestrict Flat q => MonadRestrict Flat (Restrictings Aggregated q) where
-  restrict = restrictings . restrict
+  restrictNoPh = restrictings . restrictNoPh
 
 extract :: AggregatedQuery p r
         -> ConfigureQuery ((((((((PlaceHolders p, Record Aggregated r),

--- a/relational-query/src/Database/Relational/Monad/Assign.hs
+++ b/relational-query/src/Database/Relational/Monad/Assign.hs
@@ -19,12 +19,10 @@ module Database.Relational.Monad.Assign (
   extract,
   ) where
 
-import Data.DList (DList)
-
 import Database.Relational.Internal.Config (Config)
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
-  (Predicate, Record, Assignment)
+  (Predicate, Record, PlaceholderOffsets, Assignment)
 
 import Database.Relational.Table (Table)
 import Database.Relational.Monad.Restrict (RestrictNoPh)
@@ -43,5 +41,5 @@ type Assign r = ReferredPlaceholders (Assignings r RestrictNoPh)
 type AssignStatement r a = Record Flat r -> Assign r a
 
 -- | Run 'Assign'.
-extract :: Assign r a -> Config -> (((a, DList Int), Table r -> [Assignment]), [Predicate Flat])
+extract :: Assign r a -> Config -> (((a, PlaceholderOffsets), Table r -> [Assignment]), [Predicate Flat])
 extract =  Restrict.extractNoPh . extractAssignments . extractReferredPlaceholders

--- a/relational-query/src/Database/Relational/Monad/Assign.hs
+++ b/relational-query/src/Database/Relational/Monad/Assign.hs
@@ -19,6 +19,8 @@ module Database.Relational.Monad.Assign (
   extract,
   ) where
 
+import Data.DList (DList)
+
 import Database.Relational.Internal.Config (Config)
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
@@ -28,10 +30,11 @@ import Database.Relational.Table (Table)
 import Database.Relational.Monad.Restrict (Restrict)
 import qualified Database.Relational.Monad.Restrict as Restrict
 import Database.Relational.Monad.Trans.Assigning (Assignings, extractAssignments)
+import Database.Relational.Monad.Trans.ReferredPlaceholders (ReferredPlaceholders, extractReferredPlaceholders)
 
 
 -- | Target update monad type used from update statement and merge statement.
-type Assign r = Assignings r Restrict
+type Assign r = ReferredPlaceholders (Assignings r Restrict)
 
 -- | AssignStatement type synonym.
 --   Specifying assignments and restrictions like update statement.
@@ -44,5 +47,5 @@ type AssignStatement r a = Record Flat r -> Assign r a
 -- updateStatement =  assignings . restrictings . Identity
 
 -- | Run 'Assign'.
-extract :: Assign r a -> Config -> ((a, Table r -> [Assignment]), [Predicate Flat])
-extract =  Restrict.extract . extractAssignments
+extract :: Assign r a -> Config -> (((a, DList Int), Table r -> [Assignment]), [Predicate Flat])
+extract =  Restrict.extract . extractAssignments . extractReferredPlaceholders

--- a/relational-query/src/Database/Relational/Monad/Assign.hs
+++ b/relational-query/src/Database/Relational/Monad/Assign.hs
@@ -27,14 +27,14 @@ import Database.Relational.SqlSyntax
   (Predicate, Record, Assignment)
 
 import Database.Relational.Table (Table)
-import Database.Relational.Monad.Restrict (Restrict)
+import Database.Relational.Monad.Restrict (RestrictNoPh)
 import qualified Database.Relational.Monad.Restrict as Restrict
 import Database.Relational.Monad.Trans.Assigning (Assignings, extractAssignments)
 import Database.Relational.Monad.Trans.ReferredPlaceholders (ReferredPlaceholders, extractReferredPlaceholders)
 
 
 -- | Target update monad type used from update statement and merge statement.
-type Assign r = ReferredPlaceholders (Assignings r Restrict)
+type Assign r = ReferredPlaceholders (Assignings r RestrictNoPh)
 
 -- | AssignStatement type synonym.
 --   Specifying assignments and restrictions like update statement.
@@ -42,10 +42,6 @@ type Assign r = ReferredPlaceholders (Assignings r Restrict)
 --   the same as 'Target' type parameter 'r'.
 type AssignStatement r a = Record Flat r -> Assign r a
 
--- -- | 'return' of 'Update'
--- updateStatement :: a -> Assignings r (Restrictings Identity) a
--- updateStatement =  assignings . restrictings . Identity
-
 -- | Run 'Assign'.
 extract :: Assign r a -> Config -> (((a, DList Int), Table r -> [Assignment]), [Predicate Flat])
-extract =  Restrict.extract . extractAssignments . extractReferredPlaceholders
+extract =  Restrict.extractNoPh . extractAssignments . extractReferredPlaceholders

--- a/relational-query/src/Database/Relational/Monad/BaseType.hs
+++ b/relational-query/src/Database/Relational/Monad/BaseType.hs
@@ -60,7 +60,6 @@ unsafeTypeRelation :: ConfigureQuery (DList Int, SubQuery) -> Relation p r
 unsafeTypeRelation = SubQuery
 
 -- | Sub-query Qualify monad from relation.
--- igrep TODO: Maybe should rename!
 untypeRelation :: Relation p r -> ConfigureQuery (DList Int, SubQuery)
 untypeRelation (SubQuery qps) = qps
 

--- a/relational-query/src/Database/Relational/Monad/BaseType.hs
+++ b/relational-query/src/Database/Relational/Monad/BaseType.hs
@@ -22,7 +22,6 @@ module Database.Relational.Monad.BaseType
          rightPh, leftPh,
        ) where
 
-import Data.DList (DList)
 import Data.Functor.Identity (Identity, runIdentity)
 import Control.Applicative ((<$>))
 
@@ -30,7 +29,7 @@ import Database.Record.Persistable (PersistableRecordWidth, unsafePersistableRec
 
 import Database.Relational.Internal.String (StringSQL, showStringSQL)
 import Database.Relational.Internal.Config (Config, defaultConfig)
-import Database.Relational.SqlSyntax (Qualified, SubQuery, showSQL, width)
+import Database.Relational.SqlSyntax (Qualified, SubQuery, PlaceholderOffsets, showSQL, width)
 
 import qualified Database.Relational.Monad.Trans.Qualify as Qualify
 import Database.Relational.Monad.Trans.Qualify (Qualify, qualify, evalQualifyPrime)
@@ -53,14 +52,14 @@ askConfig =  qualify askQueryConfig
 
 
 -- | Relation type with place-holder parameter 'p' and query result type 'r'.
-newtype Relation p r = SubQuery (ConfigureQuery (DList Int, SubQuery))
+newtype Relation p r = SubQuery (ConfigureQuery (PlaceholderOffsets, SubQuery))
 
 -- | Unsafely type qualified subquery into record typed relation type.
-unsafeTypeRelation :: ConfigureQuery (DList Int, SubQuery) -> Relation p r
+unsafeTypeRelation :: ConfigureQuery (PlaceholderOffsets, SubQuery) -> Relation p r
 unsafeTypeRelation = SubQuery
 
 -- | Sub-query Qualify monad from relation.
-untypeRelation :: Relation p r -> ConfigureQuery (DList Int, SubQuery)
+untypeRelation :: Relation p r -> ConfigureQuery (PlaceholderOffsets, SubQuery)
 untypeRelation (SubQuery qps) = qps
 
 untypeRelationNoPlaceholders :: Relation p r -> ConfigureQuery SubQuery

--- a/relational-query/src/Database/Relational/Monad/Class.hs
+++ b/relational-query/src/Database/Relational/Monad/Class.hs
@@ -16,10 +16,13 @@ module Database.Relational.Monad.Class
        ( -- * Query interface classes
          MonadQualify (..), MonadRestrict (..),
          MonadQuery (..), MonadAggregate (..), MonadPartition (..),
+         MonadReferPlaceholders (..),
 
          all', distinct,
          on, wheres, having,
        ) where
+
+import Data.DList (DList)
 
 import Database.Relational.Internal.ContextType (Flat, Aggregated)
 import Database.Relational.SqlSyntax
@@ -72,6 +75,10 @@ class MonadQuery m => MonadAggregate m where
 class Monad m => MonadPartition c m where
   -- | Add /PARTITION BY/ term into context.
   partitionBy :: Record c r -> m ()
+
+class Monad m => MonadReferPlaceholders m where
+  appendPlaceholderOffsets :: DList Int -> m ()
+
 
 -- | Specify ALL attribute to query context.
 all' :: MonadQuery m => m ()

--- a/relational-query/src/Database/Relational/Monad/Class.hs
+++ b/relational-query/src/Database/Relational/Monad/Class.hs
@@ -16,13 +16,8 @@ module Database.Relational.Monad.Class
        ( -- * Query interface classes
          MonadQualify (..), MonadRestrict (..),
          MonadQuery (..), MonadAggregate (..), MonadPartition (..),
-         MonadReferPlaceholders (..),
-
          all', distinct,
-         on, wheres, having,
        ) where
-
-import Data.DList (DList)
 
 import Database.Relational.Internal.ContextType (Flat, Aggregated)
 import Database.Relational.SqlSyntax
@@ -35,23 +30,23 @@ import Database.Relational.Monad.BaseType (ConfigureQuery, Relation)
 -- | Restrict context interface
 class (Functor m, Monad m) => MonadRestrict c m where
   -- | Add restriction to this context.
-  restrict :: Predicate c -- ^ 'Record' which represent restriction
-           -> m ()        -- ^ Restricted query context
+  restrictNoPh :: Predicate c -- ^ 'Record' which represent restriction
+               -> m ()        -- ^ Restricted query context
 
 -- | Query building interface.
 class (Functor m, Monad m, MonadQualify ConfigureQuery m) => MonadQuery m where
   -- | Specify duplication.
   setDuplication :: Duplication -> m ()
   -- | Add restriction to last join.
-  restrictJoin :: Predicate Flat -- ^ 'Record' which represent restriction
-               -> m ()           -- ^ Restricted query context
+  restrictJoinNoPh :: Predicate Flat -- ^ 'Record' which represent restriction
+                   -> m ()           -- ^ Restricted query context
   {- Haddock BUG? -}
   -- | Join sub-query with place-holder parameter 'p'. query result is not 'Maybe'.
-  query' :: Relation p r
-         -> m (PlaceHolders p, Record Flat r)
+  queryNoPh' :: Relation p r
+             -> m (PlaceHolders p, Record Flat r)
   -- | Join sub-query with place-holder parameter 'p'. Query result is 'Maybe'.
-  queryMaybe' :: Relation p r
-              -> m (PlaceHolders p, Record Flat (Maybe r))
+  queryMaybeNoPh' :: Relation p r
+                  -> m (PlaceHolders p, Record Flat (Maybe r))
 
 -- | Lift interface from base qualify monad.
 class (Functor q, Monad q, Functor m, Monad m) => MonadQualify q m where
@@ -65,19 +60,16 @@ instance (Functor q, Monad q) => MonadQualify q q where
 -- | Aggregated query building interface extends 'MonadQuery'.
 class MonadQuery m => MonadAggregate m where
   -- | Add /GROUP BY/ term into context and get aggregated record.
-  groupBy :: Record Flat r           -- ^ Record to add into group by
-          -> m (Record Aggregated r) -- ^ Result context and aggregated record
+  groupByNoPh :: Record Flat r           -- ^ Record to add into group by
+              -> m (Record Aggregated r) -- ^ Result context and aggregated record
   -- | Add /GROUP BY/ term into context and get aggregated record. Non-traditional group-by version.
-  groupBy' :: AggregateKey (Record Aggregated r)  -- ^ Key to aggretate for non-traditional group-by interface
-           -> m (Record Aggregated r)             -- ^ Result context and aggregated record
+  groupByNoPh' :: AggregateKey (Record Aggregated r)  -- ^ Key to aggretate for non-traditional group-by interface
+               -> m (Record Aggregated r)             -- ^ Result context and aggregated record
 
 -- | Window specification building interface.
 class Monad m => MonadPartition c m where
   -- | Add /PARTITION BY/ term into context.
-  partitionBy :: Record c r -> m ()
-
-class Monad m => MonadReferPlaceholders m where
-  appendPlaceholderOffsets :: DList Int -> m ()
+  partitionByNoPh :: Record c r -> m ()
 
 
 -- | Specify ALL attribute to query context.
@@ -87,15 +79,3 @@ all' =  setDuplication All
 -- | Specify DISTINCT attribute to query context.
 distinct :: MonadQuery m => m ()
 distinct =  setDuplication Distinct
-
--- | Add restriction to last join. Record type version.
-on :: MonadQuery m => Predicate Flat -> m ()
-on =  restrictJoin
-
--- | Add restriction to this not aggregated query.
-wheres :: MonadRestrict Flat m => Predicate Flat -> m ()
-wheres =  restrict
-
--- | Add restriction to this aggregated query. Aggregated Record type version.
-having :: MonadRestrict Aggregated m => Predicate Aggregated -> m ()
-having =  restrict

--- a/relational-query/src/Database/Relational/Monad/ReferPlaceholders.hs
+++ b/relational-query/src/Database/Relational/Monad/ReferPlaceholders.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | Monadic actions wrapped to record 'referredPlaceholders' of 'Record'
+module Database.Relational.Monad.ReferPlaceholders
+  ( query' , queryMaybe'
+  , on
+  , wheres, having
+  , groupBy, groupBy', partitionBy
+  , orderBy, orderBy', asc, desc
+  , assignTo , (<-#)
+  ) where
+
+
+import Database.Relational.SqlSyntax
+  (Predicate, Record, AggregateKey, Order (..), Nulls (..), emptyPlaceholderOffsets, aggregateKeyRecord)
+import Database.Relational.Internal.ContextType (Flat, Aggregated)
+import Database.Relational.Monad.BaseType
+  (Relation, ConfigureQuery, untypeRelation, unsafeTypeRelation)
+import Database.Relational.Monad.Class
+import Database.Relational.Monad.Trans.Assigning
+import Database.Relational.Monad.Trans.Ordering
+import Database.Relational.Monad.Trans.ReferredPlaceholders
+import Database.Relational.Projectable (PlaceHolders)
+
+query' :: MonadQuery m => Relation p r -> ReferredPlaceholders m (PlaceHolders p, Record Flat r)
+query' = appendingPlaceholdersOfRelation queryNoPh'
+
+queryMaybe' :: MonadQuery m => Relation p r -> ReferredPlaceholders m (PlaceHolders p, Record Flat (Maybe r))
+queryMaybe' = appendingPlaceholdersOfRelation queryMaybeNoPh'
+
+-- | Add restriction to last join. Record type version.
+on :: MonadQuery m => Predicate Flat -> ReferredPlaceholders m ()
+on =  appendingPlaceholdersOfRecord restrictJoinNoPh
+
+-- | Add restriction to this not aggregated query.
+wheres :: MonadRestrict Flat m => Predicate Flat -> ReferredPlaceholders m ()
+wheres =  appendingPlaceholdersOfRecord restrictNoPh
+
+-- | Add restriction to this aggregated query. Aggregated Record type version.
+having :: MonadRestrict Aggregated m => Predicate Aggregated -> ReferredPlaceholders m ()
+having =  appendingPlaceholdersOfRecord restrictNoPh
+
+groupBy
+  :: MonadAggregate m
+  => Record Flat r
+  -- ^ Record to add into group by
+  -> ReferredPlaceholders m (Record Aggregated r)
+  -- ^ Result context and aggregated record
+groupBy = appendingPlaceholdersOfRecord groupByNoPh
+
+groupBy'
+  :: MonadAggregate m
+  => AggregateKey (Record Aggregated r)
+  -- ^ Key to aggretate for non-traditional group-by interface
+  -> ReferredPlaceholders m (Record Aggregated r)
+  -- ^ Result context and aggregated record
+groupBy' key = do
+  let r = aggregateKeyRecord key
+  appendPlaceholdersOfRecord r
+  referredPlaceholders $ groupByNoPh' (emptyPlaceholderOffsets <$> key)
+
+-- | Add /PARTITION BY/ term into context.
+partitionBy :: MonadPartition c m => Record c r -> ReferredPlaceholders m ()
+partitionBy = appendingPlaceholdersOfRecord partitionByNoPh
+
+-- | Add ordering terms with null ordering.
+orderBy'
+  :: Monad m
+  => Record c t                              -- ^ Ordering terms to add
+  -> Order                                   -- ^ Order direction
+  -> Nulls                                   -- ^ Order of null
+  -> ReferredPlaceholders (Orderings c m) () -- ^ Result context with ordering
+orderBy' p o n = appendingPlaceholdersOfRecord (\r -> orderByNoPh' r o n) p
+
+-- | Add ordering terms.
+orderBy
+  :: Monad m
+  => Record c t                              -- ^ Ordering terms to add
+  -> Order                                   -- ^ Order direction
+  -> ReferredPlaceholders (Orderings c m) () -- ^ Result context with ordering
+orderBy p o = appendingPlaceholdersOfRecord (`orderByNoPh` o) p
+
+-- | Add ascendant ordering term.
+asc
+  :: Monad m
+  => Record c t                              -- ^ Ordering terms to add
+  -> ReferredPlaceholders (Orderings c m) () -- ^ Result context with ordering
+asc = appendingPlaceholdersOfRecord ascNoPh
+
+-- | Add descendant ordering term.
+desc
+  :: Monad m
+  => Record c t                              -- ^ Ordering terms to add
+  -> ReferredPlaceholders (Orderings c m) () -- ^ Result context with ordering
+desc = appendingPlaceholdersOfRecord descNoPh
+
+-- | Add an assignment.
+assignTo :: Monad m => Record Flat v ->  AssignTarget r v -> ReferredPlaceholders (Assignings r m) ()
+assignTo vp target = appendingPlaceholdersOfRecord (`assignToNoPh` target) vp
+
+-- | Add and assginment.
+(<-#) :: Monad m => AssignTarget r v -> Record Flat v -> ReferredPlaceholders (Assignings r m) ()
+(<-#) =  flip assignTo
+
+infix 4 <-#
+
+appendingPlaceholdersOfRecord :: Monad m => (Record c a -> m b) -> Record c a -> ReferredPlaceholders m b
+appendingPlaceholdersOfRecord act r = do
+  appendPlaceholdersOfRecord r
+  referredPlaceholders (act $ emptyPlaceholderOffsets r)
+
+appendingPlaceholdersOfRelation
+  :: MonadQualify ConfigureQuery m => (Relation p a -> m b) -> Relation p a -> ReferredPlaceholders m b
+appendingPlaceholdersOfRelation act r = do
+  (phs, subq) <- liftQualify $ untypeRelation r
+  appendPlaceholderOffsets phs
+  let r' = unsafeTypeRelation $ return (mempty, subq)
+  referredPlaceholders (act r')

--- a/relational-query/src/Database/Relational/Monad/Register.hs
+++ b/relational-query/src/Database/Relational/Monad/Register.hs
@@ -15,17 +15,20 @@ module Database.Relational.Monad.Register (
   extract,
   ) where
 
+import Data.DList (DList)
+
 import Database.Relational.Internal.Config (Config)
 import Database.Relational.SqlSyntax (Assignment)
 
 import Database.Relational.Table (Table)
 import Database.Relational.Monad.BaseType (ConfigureQuery, configureQuery)
 import Database.Relational.Monad.Trans.Assigning (Assignings, extractAssignments)
+import Database.Relational.Monad.Trans.ReferredPlaceholders (ReferredPlaceholders, extractReferredPlaceholders)
 
 
 -- | Target register monad type used from insert statement.
-type Register r = Assignings r ConfigureQuery
+type Register r = ReferredPlaceholders (Assignings r ConfigureQuery)
 
 -- | Run 'InsertStatement'.
-extract :: Assignings r ConfigureQuery a -> Config -> (a, Table r -> [Assignment])
-extract = configureQuery . extractAssignments
+extract :: Register r a -> Config -> ((a, DList Int), Table r -> [Assignment])
+extract = configureQuery . extractAssignments . extractReferredPlaceholders

--- a/relational-query/src/Database/Relational/Monad/Register.hs
+++ b/relational-query/src/Database/Relational/Monad/Register.hs
@@ -15,10 +15,8 @@ module Database.Relational.Monad.Register (
   extract,
   ) where
 
-import Data.DList (DList)
-
 import Database.Relational.Internal.Config (Config)
-import Database.Relational.SqlSyntax (Assignment)
+import Database.Relational.SqlSyntax (Assignment, PlaceholderOffsets)
 
 import Database.Relational.Table (Table)
 import Database.Relational.Monad.BaseType (ConfigureQuery, configureQuery)
@@ -30,5 +28,5 @@ import Database.Relational.Monad.Trans.ReferredPlaceholders (ReferredPlaceholder
 type Register r = ReferredPlaceholders (Assignings r ConfigureQuery)
 
 -- | Run 'InsertStatement'.
-extract :: Register r a -> Config -> ((a, DList Int), Table r -> [Assignment])
+extract :: Register r a -> Config -> ((a, PlaceholderOffsets), Table r -> [Assignment])
 extract = configureQuery . extractAssignments . extractReferredPlaceholders

--- a/relational-query/src/Database/Relational/Monad/Restrict.hs
+++ b/relational-query/src/Database/Relational/Monad/Restrict.hs
@@ -21,11 +21,9 @@ module Database.Relational.Monad.Restrict (
   extractNoPh
   ) where
 
-import Data.DList (DList)
-
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.Internal.Config (Config)
-import Database.Relational.SqlSyntax (Predicate, Record)
+import Database.Relational.SqlSyntax (Predicate, Record, PlaceholderOffsets)
 
 import Database.Relational.Monad.BaseType (ConfigureQuery, configureQuery)
 import Database.Relational.Monad.Trans.Restricting
@@ -44,7 +42,7 @@ type RestrictNoPh = Restrictings Flat ConfigureQuery
 type RestrictedStatement r a = Record Flat r -> Restrict a
 
 -- | Run 'Restrict' to get 'QueryRestriction'.
-extract :: Restrict a -> Config -> ((a, DList Int), [Predicate Flat])
+extract :: Restrict a -> Config -> ((a, PlaceholderOffsets), [Predicate Flat])
 extract =  configureQuery . extractRestrict . extractReferredPlaceholders
 
 -- | Run 'Restrict' to get 'QueryRestriction'.

--- a/relational-query/src/Database/Relational/Monad/Simple.hs
+++ b/relational-query/src/Database/Relational/Monad/Simple.hs
@@ -22,6 +22,7 @@ module Database.Relational.Monad.Simple (
   toSubQuery,
   ) where
 
+import Data.DList (DList)
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
   (Duplication, OrderingTerm, JoinProduct, Predicate,  Record,
@@ -30,38 +31,40 @@ import qualified Database.Relational.SqlSyntax as Syntax
 
 import qualified Database.Relational.Record as Record
 import Database.Relational.Monad.Trans.Join (join')
+import Database.Relational.Monad.Trans.ReferredPlaceholders
+  (ReferredPlaceholders, extractReferredPlaceholders, referredPlaceholders)
 import Database.Relational.Monad.Trans.Restricting (restrictings)
 import Database.Relational.Monad.Trans.Ordering
   (Orderings, orderings, extractOrderingTerms)
 import Database.Relational.Monad.BaseType (ConfigureQuery, askConfig)
-import Database.Relational.Monad.Type (QueryCore, extractCore, OrderedQuery)
+import Database.Relational.Monad.Type (QueryCore, extractCore)
 import Database.Relational.Projectable (PlaceHolders)
 
 
 -- | Simple (not-aggregated) query monad type.
-type QuerySimple = Orderings Flat QueryCore
+type QuerySimple     = ReferredPlaceholders (Orderings Flat QueryCore)
 
--- | Simple (not-aggregated) query type. 'SimpleQuery'' p r == 'QuerySimple' ('PlaceHolders' p, 'Record' r).
-type SimpleQuery p r = OrderedQuery Flat QueryCore p r
+-- | Simple (not-aggregated) query type with placeholders.
+type SimpleQuery p r = ReferredPlaceholders (Orderings Flat QueryCore) (PlaceHolders p, Record Flat r)
 
 -- | Lift from qualified table forms into 'QuerySimple'.
 simple :: ConfigureQuery a -> QuerySimple a
-simple =  orderings . restrictings . join'
+simple =  referredPlaceholders . orderings . restrictings . join'
 
 extract :: SimpleQuery p r
-        -> ConfigureQuery (((((PlaceHolders p, Record Flat r), [OrderingTerm]), [Predicate Flat]),
+        -> ConfigureQuery ((((((PlaceHolders p, Record Flat r), DList Int), [OrderingTerm]), [Predicate Flat]),
                            JoinProduct), Duplication)
-extract =  extractCore . extractOrderingTerms
+extract =  extractCore . extractOrderingTerms . extractReferredPlaceholders
 
 -- | Run 'SimpleQuery' to get SQL string with 'Qualify' computation.
-toSQL :: SimpleQuery p r         -- ^ 'SimpleQuery' to run
+toSQL :: SimpleQuery p r       -- ^ 'SimpleQuery' to run
       -> ConfigureQuery String -- ^ Result SQL string with 'Qualify' computation
-toSQL =  fmap Syntax.toSQL . toSubQuery
+toSQL =  fmap (Syntax.toSQL . snd) . toSubQuery
 
 -- | Run 'SimpleQuery' to get 'SubQuery' with 'Qualify' computation.
-toSubQuery :: SimpleQuery p r        -- ^ 'SimpleQuery'' to run
-           -> ConfigureQuery SubQuery -- ^ Result 'SubQuery' with 'Qualify' computation
+toSubQuery :: SimpleQuery p r                      -- ^ 'SimpleQuery'' to run
+           -> ConfigureQuery (DList Int, SubQuery) -- ^ Result 'SubQuery' with 'Qualify' computation
 toSubQuery q = do
-   (((((_ph, pj), ot), rs), pd), da) <- extract q
+   ((((((_ph, pj), phs), ot), rs), pd), da) <- extract q
    c <- askConfig
-   return $ flatSubQuery c (Record.untype pj) da pd rs ot
+   return (phs, flatSubQuery c (Record.untype pj) da pd rs ot)

--- a/relational-query/src/Database/Relational/Monad/Simple.hs
+++ b/relational-query/src/Database/Relational/Monad/Simple.hs
@@ -22,11 +22,10 @@ module Database.Relational.Monad.Simple (
   toSubQuery,
   ) where
 
-import Data.DList (DList)
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
   (Duplication, OrderingTerm, JoinProduct, Predicate,  Record,
-   SubQuery, flatSubQuery, )
+   PlaceholderOffsets, SubQuery, flatSubQuery, )
 import qualified Database.Relational.SqlSyntax as Syntax
 
 import qualified Database.Relational.Record as Record
@@ -52,7 +51,7 @@ simple :: ConfigureQuery a -> QuerySimple a
 simple =  referredPlaceholders . orderings . restrictings . join'
 
 extract :: SimpleQuery p r
-        -> ConfigureQuery ((((((PlaceHolders p, Record Flat r), DList Int), [OrderingTerm]), [Predicate Flat]),
+        -> ConfigureQuery ((((((PlaceHolders p, Record Flat r), PlaceholderOffsets), [OrderingTerm]), [Predicate Flat]),
                            JoinProduct), Duplication)
 extract =  extractCore . extractOrderingTerms . extractReferredPlaceholders
 
@@ -63,7 +62,7 @@ toSQL =  fmap (Syntax.toSQL . snd) . toSubQuery
 
 -- | Run 'SimpleQuery' to get 'SubQuery' with 'Qualify' computation.
 toSubQuery :: SimpleQuery p r                      -- ^ 'SimpleQuery'' to run
-           -> ConfigureQuery (DList Int, SubQuery) -- ^ Result 'SubQuery' with 'Qualify' computation
+           -> ConfigureQuery (PlaceholderOffsets, SubQuery) -- ^ Result 'SubQuery' with 'Qualify' computation
 toSubQuery q = do
    ((((((_ph, pj), phs), ot), rs), pd), da) <- extract q
    c <- askConfig

--- a/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
@@ -80,7 +80,7 @@ type PartitioningSetT c   = Aggregatings c         AggregateColumnRef
 
 -- | Aggregated 'MonadRestrict'.
 instance MonadRestrict c m => MonadRestrict c (AggregatingSetT m) where
-  restrict =  aggregatings . restrict
+  restrictNoPh =  aggregatings . restrictNoPh
 
 -- | Aggregated 'MonadQualify'.
 instance MonadQualify q m => MonadQualify q (AggregatingSetT m) where
@@ -88,10 +88,10 @@ instance MonadQualify q m => MonadQualify q (AggregatingSetT m) where
 
 -- | Aggregated 'MonadQuery'.
 instance MonadQuery m => MonadQuery (AggregatingSetT m) where
-  setDuplication     = aggregatings . setDuplication
-  restrictJoin       = aggregatings . restrictJoin
-  query'             = aggregatings . query'
-  queryMaybe'        = aggregatings . queryMaybe'
+  setDuplication   = aggregatings . setDuplication
+  restrictJoinNoPh = aggregatings . restrictJoinNoPh
+  queryNoPh'       = aggregatings . queryNoPh'
+  queryMaybeNoPh'  = aggregatings . queryMaybeNoPh'
 
 unsafeAggregateWithTerm :: Monad m => at -> Aggregatings ac at m ()
 unsafeAggregateWithTerm =  Aggregatings . tell . pure
@@ -103,14 +103,14 @@ aggregateKey k = do
 
 -- | Aggregated query instance.
 instance MonadQuery m => MonadAggregate (AggregatingSetT m) where
-  groupBy p = do
+  groupByNoPh p = do
     mapM_ unsafeAggregateWithTerm [ aggregateColumnRef col | col <- untypeRecord p]
     return $ Record.unsafeToAggregated p
-  groupBy'  = aggregateKey
+  groupByNoPh'  = aggregateKey
 
 -- | Partition clause instance
 instance Monad m => MonadPartition c (PartitioningSetT c m) where
-  partitionBy =  mapM_ unsafeAggregateWithTerm . untypeRecord
+  partitionByNoPh =  mapM_ unsafeAggregateWithTerm . untypeRecord
 
 -- | Run 'Aggregatings' to get terms list.
 extractAggregateTerms :: (Monad m, Functor m) => Aggregatings ac at m a -> m (a, [at])

--- a/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
@@ -51,7 +51,6 @@ import Database.Relational.Monad.Class
     MonadQuery(..),
     MonadAggregate(..),
     MonadPartition(..),
-    MonadReferPlaceholders(..),
   )
 
 

--- a/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Aggregating.hs
@@ -46,7 +46,13 @@ import Database.Relational.SqlSyntax
 
 import qualified Database.Relational.Record as Record
 import Database.Relational.Monad.Class
-  (MonadQualify (..), MonadRestrict(..), MonadQuery(..), MonadAggregate(..), MonadPartition(..))
+  ( MonadQualify (..),
+    MonadRestrict(..),
+    MonadQuery(..),
+    MonadAggregate(..),
+    MonadPartition(..),
+    MonadReferPlaceholders(..),
+  )
 
 
 -- | Type to accumulate aggregating context.

--- a/relational-query/src/Database/Relational/Monad/Trans/Assigning.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Assigning.hs
@@ -65,6 +65,7 @@ targetRecord :: AssignTarget r v ->  Table r -> Record Flat v
 targetRecord pi' tbl = Record.wpi (recordWidth tbl) (Record.unsafeFromTable tbl) pi'
 
 -- | Add an assignment.
+-- igrep TODO: May need to save placeholders
 assignTo :: Monad m => Record Flat v ->  AssignTarget r v -> Assignings r m ()
 assignTo vp target = Assignings . tell
                      $ \t -> mconcat $ zipWith (curry pure) (leftsR t) rights  where

--- a/relational-query/src/Database/Relational/Monad/Trans/Join.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Join.hs
@@ -74,9 +74,9 @@ instance MonadQualify q m => MonadQualify q (QueryJoin m) where
 -- | Joinable query instance.
 instance MonadQuery (QueryJoin ConfigureQuery) where
   setDuplication     = QueryJoin . lift . tell . Last . Just
-  restrictJoin       = updateJoinRestriction
-  query'             = queryWithAttr Just'
-  queryMaybe' pr     = do
+  restrictJoinNoPh   = updateJoinRestriction
+  queryNoPh'         = queryWithAttr Just'
+  queryMaybeNoPh' pr = do
     (ph, pj) <- queryWithAttr Maybe pr
     return (ph, Record.just pj)
 

--- a/relational-query/src/Database/Relational/Monad/Trans/Join.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Join.hs
@@ -42,7 +42,7 @@ import Database.Relational.Monad.Trans.JoinState
   (JoinContext, primeJoinContext, updateProduct, joinProduct)
 import qualified Database.Relational.Record as Record
 import Database.Relational.Projectable (PlaceHolders, unsafeAddPlaceHolders)
-import Database.Relational.Monad.BaseType (ConfigureQuery, qualifyQuery, Relation, untypeRelation)
+import Database.Relational.Monad.BaseType (ConfigureQuery, qualifyQuery, Relation, untypeRelationNoPlaceholders)
 import Database.Relational.Monad.Class (MonadQualify (..), MonadQuery (..))
 
 
@@ -85,9 +85,9 @@ unsafeSubQueryWithAttr :: Monad q
                        => NodeAttr                 -- ^ Attribute maybe or just
                        -> Qualified SubQuery       -- ^ 'SubQuery' to join
                        -> QueryJoin q (Record c r) -- ^ Result joined context and record of 'SubQuery' result.
-unsafeSubQueryWithAttr attr qsub = do
-  updateContext (updateProduct (`growProduct` (attr, qsub)))
-  return $ Record.unsafeFromQualifiedSubQuery qsub
+unsafeSubQueryWithAttr attr qps = do
+  updateContext (updateProduct (`growProduct` (attr, qps)))
+  return $ Record.unsafeFromQualifiedSubQuery mempty qps
 
 -- | Basic monadic join operation using 'MonadQuery'.
 queryWithAttr :: NodeAttr
@@ -96,7 +96,7 @@ queryWithAttr :: NodeAttr
 queryWithAttr attr = unsafeAddPlaceHolders . run where
   run rel = do
     q <- liftQualify $ do
-      sq <- untypeRelation rel
+      sq <- untypeRelationNoPlaceholders rel
       qualifyQuery sq
     unsafeSubQueryWithAttr attr q
 

--- a/relational-query/src/Database/Relational/Monad/Trans/Ordering.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Ordering.hs
@@ -19,7 +19,7 @@ module Database.Relational.Monad.Trans.Ordering (
   Orderings, orderings,
 
   -- * API of query with ordering
-  orderBy', orderBy, asc, desc,
+  orderByNoPh', orderByNoPh, ascNoPh, descNoPh,
 
   -- * Result
   extractOrderingTerms
@@ -50,7 +50,7 @@ orderings =  lift
 
 -- | 'MonadRestrict' with ordering.
 instance MonadRestrict rc m => MonadRestrict rc (Orderings c m) where
-  restrict = orderings . restrict
+  restrictNoPh = orderings . restrictNoPh
 
 -- | 'MonadQualify' with ordering.
 instance MonadQualify q m => MonadQualify q (Orderings c m) where
@@ -58,19 +58,19 @@ instance MonadQualify q m => MonadQualify q (Orderings c m) where
 
 -- | 'MonadQuery' with ordering.
 instance MonadQuery m => MonadQuery (Orderings c m) where
-  setDuplication     = orderings . setDuplication
-  restrictJoin       = orderings . restrictJoin
-  query'             = orderings . query'
-  queryMaybe'        = orderings . queryMaybe'
+  setDuplication   = orderings . setDuplication
+  restrictJoinNoPh = orderings . restrictJoinNoPh
+  queryNoPh'       = orderings . queryNoPh'
+  queryMaybeNoPh'  = orderings . queryMaybeNoPh'
 
 -- | 'MonadAggregate' with ordering.
 instance MonadAggregate m => MonadAggregate (Orderings c m) where
-  groupBy  = orderings . groupBy
-  groupBy' = orderings . groupBy'
+  groupByNoPh  = orderings . groupByNoPh
+  groupByNoPh' = orderings . groupByNoPh'
 
 -- | 'MonadPartition' with ordering.
 instance MonadPartition c m => MonadPartition c (Orderings c m) where
-  partitionBy = orderings . partitionBy
+  partitionByNoPh = orderings . partitionByNoPh
 
 -- | Add ordering terms.
 updateOrderBys :: Monad m
@@ -81,31 +81,31 @@ updateOrderBys opair p = Orderings . mapM_ tell $ terms  where
   terms = curry pure opair `map` untypeRecord p
 
 -- | Add ordering terms with null ordering.
-orderBy' :: Monad m
-         => Record c t   -- ^ Ordering terms to add
-         -> Order            -- ^ Order direction
-         -> Nulls            -- ^ Order of null
-         -> Orderings c m () -- ^ Result context with ordering
-orderBy' p o n = updateOrderBys (o, Just n) p
+orderByNoPh' :: Monad m
+             => Record c t   -- ^ Ordering terms to add
+             -> Order            -- ^ Order direction
+             -> Nulls            -- ^ Order of null
+             -> Orderings c m () -- ^ Result context with ordering
+orderByNoPh' p o n = updateOrderBys (o, Just n) p
 
 -- | Add ordering terms.
-orderBy :: Monad m
-        => Record c t   -- ^ Ordering terms to add
-        -> Order        -- ^ Order direction
-        -> Orderings c m () -- ^ Result context with ordering
-orderBy p o = updateOrderBys (o, Nothing) p
+orderByNoPh :: Monad m
+            => Record c t   -- ^ Ordering terms to add
+            -> Order        -- ^ Order direction
+            -> Orderings c m () -- ^ Result context with ordering
+orderByNoPh p o = updateOrderBys (o, Nothing) p
 
 -- | Add ascendant ordering term.
-asc :: Monad m
-    => Record c t   -- ^ Ordering terms to add
-    -> Orderings c m () -- ^ Result context with ordering
-asc  =  updateOrderBys (Asc, Nothing)
+ascNoPh :: Monad m
+        => Record c t   -- ^ Ordering terms to add
+        -> Orderings c m () -- ^ Result context with ordering
+ascNoPh  =  updateOrderBys (Asc, Nothing)
 
 -- | Add descendant ordering term.
-desc :: Monad m
-     => Record c t   -- ^ Ordering terms to add
-     -> Orderings c m () -- ^ Result context with ordering
-desc =  updateOrderBys (Desc, Nothing)
+descNoPh :: Monad m
+         => Record c t   -- ^ Ordering terms to add
+         -> Orderings c m () -- ^ Result context with ordering
+descNoPh =  updateOrderBys (Desc, Nothing)
 
 -- | Run 'Orderings' to get 'OrderingTerms'
 extractOrderingTerms :: (Monad m, Functor m) => Orderings c m a -> m (a, [OrderingTerm])

--- a/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Database.Relational.Monad.Trans.ReferredPlaceholders where
+
+
+import Database.Relational.Monad.Class
+import Database.Relational.SqlSyntax (Record, placeholderOffsets, aggregateKeyRecord)
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Control.Monad.Trans.Writer (WriterT, runWriterT, tell)
+import Data.DList (DList)
+
+
+-- | Remember referred placeholders\' offsets.
+newtype ReferredPlaceholders m a =
+  ReferredPlaceholders ((WriterT (DList Int) m) a)
+  deriving (Functor, Applicative, Monad, MonadTrans)
+
+referredPlaceholders :: Monad m => m a -> ReferredPlaceholders m a
+referredPlaceholders = lift
+
+instance MonadRestrict c m => MonadRestrict c (ReferredPlaceholders m) where
+  restrict pd = do
+    ReferredPlaceholders . tell . placeholderOffsets $ pd
+    referredPlaceholders $ restrict pd
+
+-- igrep TODO: Add placeholders to Relation?
+instance MonadQuery m => MonadQuery (ReferredPlaceholders m) where
+  setDuplication = referredPlaceholders . setDuplication
+  restrictJoin   = referredPlaceholders . restrictJoin
+  query'         = referredPlaceholders . query'
+  queryMaybe'    = referredPlaceholders . queryMaybe'
+
+instance MonadQualify q m => MonadQualify q (ReferredPlaceholders m) where
+  liftQualify = referredPlaceholders . liftQualify
+
+instance MonadAggregate m => MonadAggregate (ReferredPlaceholders m) where
+  groupBy r = do
+    ReferredPlaceholders . tell . placeholderOffsets $ r
+    referredPlaceholders $ groupBy r
+  groupBy' r = do
+    ReferredPlaceholders . tell . placeholderOffsets $ aggregateKeyRecord r
+    referredPlaceholders $ groupBy' r
+
+instance MonadPartition c m => MonadPartition c (ReferredPlaceholders m) where
+  partitionBy r = do
+    ReferredPlaceholders . tell $ placeholderOffsets r
+    referredPlaceholders $ partitionBy r
+
+instance MonadReferPlaceholders m => MonadReferPlaceholders (ReferredPlaceholders m) where
+  appendPlaceholderOffsets = ReferredPlaceholders . tell
+
+
+appendPlaceholdersOfRecord :: (Monad m, MonadReferPlaceholders m) => Record c a -> m ()
+appendPlaceholdersOfRecord = appendPlaceholderOffsets . placeholderOffsets

--- a/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
@@ -5,12 +5,12 @@
 module Database.Relational.Monad.Trans.ReferredPlaceholders where
 
 
-import Database.Relational.Monad.Class
-import Database.Relational.SqlSyntax
-  (Record, placeholderOffsets, aggregateKeyRecord, emptyPlaceholderOffsets)
+import Data.DList (DList)
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.Trans.Writer (WriterT, runWriterT, tell)
-import Data.DList (DList)
+
+import Database.Relational.Monad.Class (MonadQualify (..), MonadQuery (..))
+import Database.Relational.SqlSyntax (Record, placeholderOffsets)
 
 
 -- | Remember referred placeholders\' offsets.
@@ -21,41 +21,20 @@ newtype ReferredPlaceholders m a =
 referredPlaceholders :: Monad m => m a -> ReferredPlaceholders m a
 referredPlaceholders = lift
 
-instance MonadRestrict c m => MonadRestrict c (ReferredPlaceholders m) where
-  restrict pd = do
-    ReferredPlaceholders . tell . placeholderOffsets $ pd
-    referredPlaceholders $ restrict pd
-
--- igrep TODO: Add placeholders to Relation?
 instance MonadQuery m => MonadQuery (ReferredPlaceholders m) where
-  setDuplication = referredPlaceholders . setDuplication
-  restrictJoin   = referredPlaceholders . restrictJoin
-  query'         = referredPlaceholders . query'
-  queryMaybe'    = referredPlaceholders . queryMaybe'
+  setDuplication   = referredPlaceholders . setDuplication
+  restrictJoinNoPh = referredPlaceholders . restrictJoinNoPh
+  queryNoPh'       = referredPlaceholders . queryNoPh'
+  queryMaybeNoPh'  = referredPlaceholders . queryMaybeNoPh'
 
 instance MonadQualify q m => MonadQualify q (ReferredPlaceholders m) where
   liftQualify = referredPlaceholders . liftQualify
 
-instance MonadAggregate m => MonadAggregate (ReferredPlaceholders m) where
-  groupBy r = do
-    ReferredPlaceholders . tell $ placeholderOffsets r
-    referredPlaceholders . groupBy $ emptyPlaceholderOffsets r
-    -- NOTE: ^ The returned record should not have any placeholderOffsets.
-    --         Because its placeholderOffsets have already been recorded the above line.
-  groupBy' k = do
-    ReferredPlaceholders . tell . placeholderOffsets $ aggregateKeyRecord k
-    referredPlaceholders (emptyPlaceholderOffsets <$> groupBy' k)
-
-instance MonadPartition c m => MonadPartition c (ReferredPlaceholders m) where
-  partitionBy r = do
-    ReferredPlaceholders . tell $ placeholderOffsets r
-    referredPlaceholders $ partitionBy r
-
-instance MonadReferPlaceholders m => MonadReferPlaceholders (ReferredPlaceholders m) where
-  appendPlaceholderOffsets = ReferredPlaceholders . tell
+appendPlaceholderOffsets :: Monad m => DList Int -> ReferredPlaceholders m ()
+appendPlaceholderOffsets = ReferredPlaceholders . tell
 
 
-appendPlaceholdersOfRecord :: (Monad m, MonadReferPlaceholders m) => Record c a -> m ()
+appendPlaceholdersOfRecord :: Monad m => Record c a -> ReferredPlaceholders m ()
 appendPlaceholdersOfRecord = appendPlaceholderOffsets . placeholderOffsets
 
 

--- a/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/ReferredPlaceholders.hs
@@ -5,17 +5,16 @@
 module Database.Relational.Monad.Trans.ReferredPlaceholders where
 
 
-import Data.DList (DList)
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.Trans.Writer (WriterT, runWriterT, tell)
 
 import Database.Relational.Monad.Class (MonadQualify (..), MonadQuery (..))
-import Database.Relational.SqlSyntax (Record, placeholderOffsets)
+import Database.Relational.SqlSyntax (Record, PlaceholderOffsets, placeholderOffsets)
 
 
 -- | Remember referred placeholders\' offsets.
 newtype ReferredPlaceholders m a =
-  ReferredPlaceholders ((WriterT (DList Int) m) a)
+  ReferredPlaceholders ((WriterT PlaceholderOffsets m) a)
   deriving (Functor, Applicative, Monad, MonadTrans)
 
 referredPlaceholders :: Monad m => m a -> ReferredPlaceholders m a
@@ -30,7 +29,7 @@ instance MonadQuery m => MonadQuery (ReferredPlaceholders m) where
 instance MonadQualify q m => MonadQualify q (ReferredPlaceholders m) where
   liftQualify = referredPlaceholders . liftQualify
 
-appendPlaceholderOffsets :: Monad m => DList Int -> ReferredPlaceholders m ()
+appendPlaceholderOffsets :: Monad m => PlaceholderOffsets -> ReferredPlaceholders m ()
 appendPlaceholderOffsets = ReferredPlaceholders . tell
 
 
@@ -38,5 +37,5 @@ appendPlaceholdersOfRecord :: Monad m => Record c a -> ReferredPlaceholders m ()
 appendPlaceholdersOfRecord = appendPlaceholderOffsets . placeholderOffsets
 
 
-extractReferredPlaceholders :: Functor m => ReferredPlaceholders m a -> m (a, DList Int)
+extractReferredPlaceholders :: Functor m => ReferredPlaceholders m a -> m (a, PlaceholderOffsets)
 extractReferredPlaceholders (ReferredPlaceholders act) = runWriterT act

--- a/relational-query/src/Database/Relational/Monad/Trans/Restricting.hs
+++ b/relational-query/src/Database/Relational/Monad/Trans/Restricting.hs
@@ -49,7 +49,7 @@ updateRestriction =  Restrictings . tell . pure
 
 -- | 'MonadRestrict' instance.
 instance (Monad q, Functor q) => MonadRestrict c (Restrictings c q) where
-  restrict = updateRestriction
+  restrictNoPh = updateRestriction
 
 -- | Restricted 'MonadQualify' instance.
 instance MonadQualify q m => MonadQualify q (Restrictings c m) where
@@ -57,15 +57,15 @@ instance MonadQualify q m => MonadQualify q (Restrictings c m) where
 
 -- | Restricted 'MonadQuery' instance.
 instance MonadQuery q => MonadQuery (Restrictings c q) where
-  setDuplication     = restrictings . setDuplication
-  restrictJoin       = restrictings . restrictJoin
-  query'             = restrictings . query'
-  queryMaybe'        = restrictings . queryMaybe'
+  setDuplication   = restrictings . setDuplication
+  restrictJoinNoPh = restrictings . restrictJoinNoPh
+  queryNoPh'       = restrictings . queryNoPh'
+  queryMaybeNoPh'  = restrictings . queryMaybeNoPh'
 
 -- | Resticted 'MonadAggregate' instance.
 instance MonadAggregate m => MonadAggregate (Restrictings c m) where
-  groupBy  = restrictings . groupBy
-  groupBy' = restrictings . groupBy'
+  groupByNoPh  = restrictings . groupByNoPh
+  groupByNoPh' = restrictings . groupByNoPh'
 
 -- | Run 'Restrictings' to get 'QueryRestriction'
 extractRestrict :: (Monad m, Functor m) => Restrictings c m a -> m (a, [Predicate c])

--- a/relational-query/src/Database/Relational/Monad/Type.hs
+++ b/relational-query/src/Database/Relational/Monad/Type.hs
@@ -11,18 +11,15 @@
 module Database.Relational.Monad.Type
        ( -- * Core query monad
          QueryCore, extractCore,
-         OrderedQuery,
        ) where
 
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
-  (Duplication, Record, JoinProduct, Predicate, )
+  (Duplication, JoinProduct, Predicate, )
 
-import Database.Relational.Projectable (PlaceHolders)
 import Database.Relational.Monad.BaseType (ConfigureQuery)
 import Database.Relational.Monad.Trans.Join (QueryJoin, extractProduct)
 import Database.Relational.Monad.Trans.Restricting (Restrictings, extractRestrict)
-import Database.Relational.Monad.Trans.Ordering (Orderings)
 
 
 -- | Core query monad type used from flat(not-aggregated) query and aggregated query.
@@ -32,6 +29,3 @@ type QueryCore = Restrictings Flat (QueryJoin ConfigureQuery)
 extractCore :: QueryCore a
             -> ConfigureQuery (((a, [Predicate Flat]), JoinProduct), Duplication)
 extractCore =  extractProduct . extractRestrict
-
--- | OrderedQuery monad type with placeholder type 'p'. Record must be the same as 'Orderings' context type parameter 'c'.
-type OrderedQuery c m p r = Orderings c m (PlaceHolders p, Record c r)

--- a/relational-query/src/Database/Relational/Monad/Unique.hs
+++ b/relational-query/src/Database/Relational/Monad/Unique.hs
@@ -15,7 +15,7 @@
 -- This module contains definitions about unique query type
 -- to support scalar queries.
 module Database.Relational.Monad.Unique
-       ( QueryUnique, unsafeUniqueSubQuery,
+       ( QueryUnique, unsafeUniqueSubQuery, liftToQueryUnique,
          toSubQuery,
        ) where
 
@@ -47,6 +47,10 @@ unsafeUniqueSubQuery :: NodeAttr                 -- ^ Attribute maybe or just
                      -> Qualified SubQuery       -- ^ 'SubQuery' to join
                      -> QueryUnique (Record c r) -- ^ Result joined context and record of 'SubQuery' result.
 unsafeUniqueSubQuery a  = QueryUnique . referredPlaceholders . restrictings . unsafeSubQueryWithAttr a
+
+-- igrep TODO: prefix by "unsafe"?
+liftToQueryUnique :: ReferredPlaceholders QueryCore a -> QueryUnique a
+liftToQueryUnique = QueryUnique
 
 extract :: QueryUnique a
         -> ConfigureQuery ((((a, DList Int), [Predicate Flat]), JoinProduct), Duplication)

--- a/relational-query/src/Database/Relational/Monad/Unique.hs
+++ b/relational-query/src/Database/Relational/Monad/Unique.hs
@@ -24,7 +24,7 @@ import Control.Applicative (Applicative)
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
   (Duplication, Record, JoinProduct, NodeAttr,
-   SubQuery, Predicate, Qualified, )
+   SubQuery, Predicate, Qualified, flatSubQuery)
 
 import qualified Database.Relational.Record as Record
 import Database.Relational.Projectable (PlaceHolders)
@@ -33,7 +33,6 @@ import Database.Relational.Monad.Trans.Join (unsafeSubQueryWithAttr)
 import Database.Relational.Monad.Trans.Restricting (restrictings)
 import Database.Relational.Monad.BaseType (ConfigureQuery, askConfig)
 import Database.Relational.Monad.Type (QueryCore, extractCore)
-import Database.Relational.SqlSyntax (flatSubQuery)
 
 
 -- | Unique query monad type.

--- a/relational-query/src/Database/Relational/Monad/Unique.hs
+++ b/relational-query/src/Database/Relational/Monad/Unique.hs
@@ -20,6 +20,7 @@ module Database.Relational.Monad.Unique
        ) where
 
 import Control.Applicative (Applicative)
+import Data.DList (DList)
 
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
@@ -30,29 +31,31 @@ import qualified Database.Relational.Record as Record
 import Database.Relational.Projectable (PlaceHolders)
 import Database.Relational.Monad.Class (MonadQualify, MonadQuery)
 import Database.Relational.Monad.Trans.Join (unsafeSubQueryWithAttr)
+import Database.Relational.Monad.Trans.ReferredPlaceholders
+  (ReferredPlaceholders, extractReferredPlaceholders, referredPlaceholders)
 import Database.Relational.Monad.Trans.Restricting (restrictings)
 import Database.Relational.Monad.BaseType (ConfigureQuery, askConfig)
 import Database.Relational.Monad.Type (QueryCore, extractCore)
 
 
 -- | Unique query monad type.
-newtype QueryUnique a = QueryUnique (QueryCore a)
+newtype QueryUnique a = QueryUnique (ReferredPlaceholders QueryCore a)
                       deriving (MonadQualify ConfigureQuery, MonadQuery, Monad, Applicative, Functor)
 
 -- | Unsafely join sub-query with this unique query.
 unsafeUniqueSubQuery :: NodeAttr                 -- ^ Attribute maybe or just
                      -> Qualified SubQuery       -- ^ 'SubQuery' to join
                      -> QueryUnique (Record c r) -- ^ Result joined context and record of 'SubQuery' result.
-unsafeUniqueSubQuery a  = QueryUnique . restrictings . unsafeSubQueryWithAttr a
+unsafeUniqueSubQuery a  = QueryUnique . referredPlaceholders . restrictings . unsafeSubQueryWithAttr a
 
 extract :: QueryUnique a
-        -> ConfigureQuery (((a, [Predicate Flat]), JoinProduct), Duplication)
-extract (QueryUnique c) = extractCore c
+        -> ConfigureQuery ((((a, DList Int), [Predicate Flat]), JoinProduct), Duplication)
+extract (QueryUnique c) = extractCore $ extractReferredPlaceholders c
 
 -- | Run 'SimpleQuery' to get 'SubQuery' with 'Qualify' computation.
 toSubQuery :: QueryUnique (PlaceHolders p, Record c r) -- ^ 'QueryUnique' to run
-           -> ConfigureQuery SubQuery                  -- ^ Result 'SubQuery' with 'Qualify' computation
+           -> ConfigureQuery (DList Int, SubQuery)     -- ^ Result 'SubQuery' with 'Qualify' computation
 toSubQuery q = do
-  ((((_ph, pj), rs), pd), da) <- extract q
+  (((((_ph, pj), phs), rs), pd), da) <- extract q
   c <- askConfig
-  return $ flatSubQuery c (Record.untype pj) da pd rs []
+  return (phs, flatSubQuery c (Record.untype pj) da pd rs [])

--- a/relational-query/src/Database/Relational/Monad/Unique.hs
+++ b/relational-query/src/Database/Relational/Monad/Unique.hs
@@ -20,11 +20,10 @@ module Database.Relational.Monad.Unique
        ) where
 
 import Control.Applicative (Applicative)
-import Data.DList (DList)
 
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
-  (Duplication, Record, JoinProduct, NodeAttr,
+  (Duplication, Record, PlaceholderOffsets, JoinProduct, NodeAttr,
    SubQuery, Predicate, Qualified, flatSubQuery)
 
 import qualified Database.Relational.Record as Record
@@ -53,12 +52,12 @@ liftToQueryUnique :: ReferredPlaceholders QueryCore a -> QueryUnique a
 liftToQueryUnique = QueryUnique
 
 extract :: QueryUnique a
-        -> ConfigureQuery ((((a, DList Int), [Predicate Flat]), JoinProduct), Duplication)
+        -> ConfigureQuery ((((a, PlaceholderOffsets), [Predicate Flat]), JoinProduct), Duplication)
 extract (QueryUnique c) = extractCore $ extractReferredPlaceholders c
 
 -- | Run 'SimpleQuery' to get 'SubQuery' with 'Qualify' computation.
 toSubQuery :: QueryUnique (PlaceHolders p, Record c r) -- ^ 'QueryUnique' to run
-           -> ConfigureQuery (DList Int, SubQuery)     -- ^ Result 'SubQuery' with 'Qualify' computation
+           -> ConfigureQuery (PlaceholderOffsets, SubQuery)     -- ^ Result 'SubQuery' with 'Qualify' computation
 toSubQuery q = do
   (((((_ph, pj), phs), rs), pd), da) <- extract q
   c <- askConfig

--- a/relational-query/src/Database/Relational/Projectable.hs
+++ b/relational-query/src/Database/Relational/Projectable.hs
@@ -80,7 +80,6 @@ module Database.Relational.Projectable (
 import Prelude hiding (pi)
 
 import Data.String (IsString)
-import Data.DList (DList)
 import Data.Monoid ((<>))
 import Data.Functor.ProductIsomorphic
   ((|$|), ProductIsoApplicative, pureP, (|*|), )
@@ -95,7 +94,7 @@ import Database.Record.Persistable (runPersistableRecordWidth)
 
 import Database.Relational.Internal.ContextType (Flat, Exists, OverWindow)
 import Database.Relational.Internal.String (StringSQL, stringSQL, showStringSQL)
-import Database.Relational.SqlSyntax (Record, Predicate)
+import Database.Relational.SqlSyntax (Record, Predicate, PlaceholderOffsets)
 import qualified Database.Relational.SqlSyntax as Syntax
 
 import Database.Relational.Pure ()
@@ -120,11 +119,11 @@ unsafeProjectSql :: SqlContext c => String -> Record c t
 unsafeProjectSql = unsafeProjectSqlWithPlaceholders mempty
 
 -- | Unsafely Project single SQL term.
-unsafeProjectSqlWithPlaceholders' :: SqlContext c => DList Int -> StringSQL -> Record c t
+unsafeProjectSqlWithPlaceholders' :: SqlContext c => PlaceholderOffsets -> StringSQL -> Record c t
 unsafeProjectSqlWithPlaceholders' phs = unsafeProjectSqlTermsWithPlaceholders phs . (:[])
 
 -- | Unsafely Project single SQL string. String interface of 'unsafeProjectSql'''.
-unsafeProjectSqlWithPlaceholders :: SqlContext c => DList Int -> String -> Record c t
+unsafeProjectSqlWithPlaceholders :: SqlContext c => PlaceholderOffsets -> String -> Record c t
 unsafeProjectSqlWithPlaceholders phs = unsafeProjectSqlWithPlaceholders' phs . stringSQL
 
 -- | Record with polymorphic phantom type of SQL null value. Semantics of comparing is unsafe.

--- a/relational-query/src/Database/Relational/Projectable.hs
+++ b/relational-query/src/Database/Relational/Projectable.hs
@@ -401,7 +401,6 @@ caseMaybe :: (OperatorContext c {- (Record c) is always ProjectableMaybe -}, Per
 caseMaybe v cs = case' v cs nothing
 
 -- | Binary operator corresponding SQL /IN/ .
--- | igrep TODO: append placeholderOffsets
 in' :: OperatorContext c
     => Record c t -> RecordList (Record c) t -> Record c (Maybe Bool)
 in' a lp =

--- a/relational-query/src/Database/Relational/Projectable/Instances.hs
+++ b/relational-query/src/Database/Relational/Projectable/Instances.hs
@@ -27,15 +27,15 @@ import Database.Relational.Projectable.Unsafe
 
 -- | Unsafely make 'Record' from SQL terms.
 instance SqlContext Flat where
-  unsafeProjectSqlTerms = Record.unsafeFromSqlTerms
+  unsafeProjectSqlTermsWithPlaceholders = Record.unsafeFromSqlTerms
 
 -- | Unsafely make 'Record' from SQL terms.
 instance SqlContext Aggregated where
-  unsafeProjectSqlTerms = Record.unsafeFromSqlTerms
+  unsafeProjectSqlTermsWithPlaceholders = Record.unsafeFromSqlTerms
 
 -- | Unsafely make 'Record' from SQL terms.
 instance SqlContext OverWindow where
-  unsafeProjectSqlTerms = Record.unsafeFromSqlTerms
+  unsafeProjectSqlTermsWithPlaceholders = Record.unsafeFromSqlTerms
 
 -- | full SQL expression is availabe in Flat context
 instance OperatorContext Flat

--- a/relational-query/src/Database/Relational/Projectable/Unsafe.hs
+++ b/relational-query/src/Database/Relational/Projectable/Unsafe.hs
@@ -9,17 +9,18 @@
 --
 -- This module provides unsafe interfaces between projected terms and SQL terms.
 module Database.Relational.Projectable.Unsafe (
-  SqlContext (..), OperatorContext, AggregatedContext,
-  PlaceHolders (..)
+  SqlContext (..), OperatorContext, AggregatedContext, PlaceHolders (..)
   ) where
 
 import Database.Relational.Internal.String (StringSQL)
 import Database.Relational.SqlSyntax (Record)
+import Data.DList (DList)
 
 -- | Interface to project SQL terms unsafely.
 class SqlContext c where
   -- | Unsafely project from SQL expression terms.
-  unsafeProjectSqlTerms :: [StringSQL]
+  unsafeProjectSqlTerms :: DList Int
+                        -> [StringSQL]
                         -> Record c t
 
 -- | Constraint to restrict context of full SQL expressions.

--- a/relational-query/src/Database/Relational/Projectable/Unsafe.hs
+++ b/relational-query/src/Database/Relational/Projectable/Unsafe.hs
@@ -14,15 +14,14 @@ module Database.Relational.Projectable.Unsafe (
   ) where
 
 import Database.Relational.Internal.String (StringSQL)
-import Database.Relational.SqlSyntax (Record)
-import Data.DList (DList)
+import Database.Relational.SqlSyntax (Record, PlaceholderOffsets)
 import Data.Monoid (mempty)
 
 -- | Interface to project SQL terms unsafely.
 class SqlContext c where
   -- | Unsafely project from SQL expression terms.
   unsafeProjectSqlTermsWithPlaceholders
-    :: DList Int -> [StringSQL] -> Record c t
+    :: PlaceholderOffsets -> [StringSQL] -> Record c t
 
 -- | Constraint to restrict context of full SQL expressions.
 --   For example, the expression at the left of OVER clause

--- a/relational-query/src/Database/Relational/Projectable/Unsafe.hs
+++ b/relational-query/src/Database/Relational/Projectable/Unsafe.hs
@@ -9,19 +9,20 @@
 --
 -- This module provides unsafe interfaces between projected terms and SQL terms.
 module Database.Relational.Projectable.Unsafe (
-  SqlContext (..), OperatorContext, AggregatedContext, PlaceHolders (..)
+  SqlContext (..), OperatorContext, AggregatedContext, PlaceHolders (..),
+  unsafeProjectSqlTerms,
   ) where
 
 import Database.Relational.Internal.String (StringSQL)
 import Database.Relational.SqlSyntax (Record)
 import Data.DList (DList)
+import Data.Monoid (mempty)
 
 -- | Interface to project SQL terms unsafely.
 class SqlContext c where
   -- | Unsafely project from SQL expression terms.
-  unsafeProjectSqlTerms :: DList Int
-                        -> [StringSQL]
-                        -> Record c t
+  unsafeProjectSqlTermsWithPlaceholders
+    :: DList Int -> [StringSQL] -> Record c t
 
 -- | Constraint to restrict context of full SQL expressions.
 --   For example, the expression at the left of OVER clause
@@ -34,3 +35,6 @@ class AggregatedContext ac
 
 -- | Placeholder parameter type which has real parameter type arguemnt 'p'.
 data PlaceHolders p = PlaceHolders
+
+unsafeProjectSqlTerms :: SqlContext c => [StringSQL] -> Record c t
+unsafeProjectSqlTerms = unsafeProjectSqlTermsWithPlaceholders mempty

--- a/relational-query/src/Database/Relational/Record.hs
+++ b/relational-query/src/Database/Relational/Record.hs
@@ -43,7 +43,7 @@ module Database.Relational.Record (
   ) where
 
 import Prelude hiding (pi)
-import Data.DList (DList, fromList)
+import Data.DList (fromList)
 import Data.Functor.ProductIsomorphic
   (ProductIsoFunctor, (|$|), ProductIsoApplicative, pureP, (|*|),
    ProductIsoEmpty, pureE, peRight, peLeft, )

--- a/relational-query/src/Database/Relational/Sequence.hs
+++ b/relational-query/src/Database/Relational/Sequence.hs
@@ -30,13 +30,10 @@ module Database.Relational.Sequence (
   updateNumber', updateNumber,
   ) where
 
-import Prelude hiding (seq)
-
 import Database.Record (PersistableWidth)
 import Database.Relational.Internal.Config (Config, defaultConfig)
-import Database.Relational.Monad.Class (wheres)
 import Database.Relational.Monad.BaseType (Relation)
-import Database.Relational.Monad.Trans.Assigning ((<-#))
+import Database.Relational.Monad.ReferPlaceholders (wheres, (<-#))
 import Database.Relational.Table (TableDerivable, derivedTable, Table)
 import Database.Relational.Pi (Pi)
 import Database.Relational.Constraint

--- a/relational-query/src/Database/Relational/Set.hs
+++ b/relational-query/src/Database/Relational/Set.hs
@@ -24,6 +24,7 @@ module Database.Relational.Set (
   ) where
 
 import Data.Functor.ProductIsomorphic ((|$|), (|*|))
+import Data.Monoid ((<>))
 
 import Database.Relational.Internal.ContextType (Flat)
 import Database.Relational.SqlSyntax
@@ -143,9 +144,9 @@ unsafeLiftAppend :: (SubQuery -> SubQuery -> SubQuery)
            -> Relation q a
            -> Relation r a
 unsafeLiftAppend op a0 a1 = unsafeTypeRelation $ do
-  s0 <- untypeRelation a0
-  s1 <- untypeRelation a1
-  return $ s0 `op` s1
+  (phs0, s0) <- untypeRelation a0
+  (phs1, s1) <- untypeRelation a1
+  return (phs0 <> phs1, s0 `op` s1)
 
 liftAppend :: (SubQuery -> SubQuery -> SubQuery)
            -> Relation () a

--- a/relational-query/src/Database/Relational/Set.hs
+++ b/relational-query/src/Database/Relational/Set.hs
@@ -33,7 +33,7 @@ import qualified Database.Relational.SqlSyntax as Syntax
 
 import Database.Relational.Monad.BaseType
   (Relation, unsafeTypeRelation, untypeRelation, )
-import Database.Relational.Monad.Class (MonadQuery (query', queryMaybe'), on)
+import Database.Relational.Monad.ReferPlaceholders (query', queryMaybe', on)
 import Database.Relational.Monad.Simple (QuerySimple)
 import Database.Relational.Projectable (PlaceHolders)
 import Database.Relational.Relation (relation', relation, query, queryMaybe, )

--- a/relational-query/src/Database/Relational/SqlSyntax/Fold.hs
+++ b/relational-query/src/Database/Relational/SqlSyntax/Fold.hs
@@ -157,9 +157,11 @@ toSQLs =  d  where
   d (Flat cf up da pd rs od)   = (SQL.paren q, q)  where
     q = selectPrefixSQL up da <> showsJoinProduct (productUnitSupport cf) pd <> composeWhere rs
         <> composeOrderBy od
+        -- ^ igrep TODO: Reorder PlaceholderOffsets here
   d (Aggregated cf up da pd rs ag grs od) = (SQL.paren q, q)  where
     q = selectPrefixSQL up da <> showsJoinProduct (productUnitSupport cf) pd <> composeWhere rs
         <> composeGroupBy ag <> composeHaving grs <> composeOrderBy od
+        -- ^ igrep TODO: Reorder PlaceholderOffsets here
 
 showUnitSQL :: SubQuery -> StringSQL
 showUnitSQL =  fst . toSQLs

--- a/relational-query/src/Database/Relational/SqlSyntax/Types.hs
+++ b/relational-query/src/Database/Relational/SqlSyntax/Types.hs
@@ -108,7 +108,7 @@ data AggregateElem = ColumnRef AggregateColumnRef
                    deriving Show
 
 -- | Typeful aggregate element.
-newtype AggregateKey a = AggregateKey (a, AggregateElem)
+newtype AggregateKey a = AggregateKey (a, AggregateElem) deriving Functor
 
 -- | Sub-query type
 data SubQuery = Table Untyped

--- a/relational-query/src/Database/Relational/SqlSyntax/Types.hs
+++ b/relational-query/src/Database/Relational/SqlSyntax/Types.hs
@@ -51,6 +51,7 @@ module Database.Relational.SqlSyntax.Types (
   -- * Manipulate records representing placeholders
   toPlaceholdersRecord,
   isPlaceholders,
+  emptyPlaceholderOffsets,
   appendPlaceholderOffsetsOf,
 
   -- * Predicate to restrict Query result
@@ -222,13 +223,13 @@ typeFromRawColumns :: DList Int
 typeFromRawColumns phs =  record phs . map RawColumn
 
 toPlaceholdersRecord :: Record c r -> Record c r
-toPlaceholdersRecord r = setPlaceholdersOffsets [0 .. tupleWidth (untypeRecord r) - 1] r
+toPlaceholdersRecord r = r { placeholderOffsets = fromList [0 .. tupleWidth (untypeRecord r) - 1] }
 
 isPlaceholders :: Record c r -> Bool
 isPlaceholders = (/= mempty) . placeholderOffsets
 
-setPlaceholdersOffsets :: [Int] ->  Record c r -> Record c r
-setPlaceholdersOffsets os r = r { placeholderOffsets = fromList os }
+emptyPlaceholderOffsets :: Record c r -> Record c r
+emptyPlaceholderOffsets r = r { placeholderOffsets = mempty }
 
 appendPlaceholderOffsetsOf :: Record c1 a -> Record c2 b -> DList Int
 appendPlaceholderOffsetsOf src1 src2 = placeholderOffsets src1 <> placeholderOffsets src2

--- a/relational-query/src/Database/Relational/TH.hs
+++ b/relational-query/src/Database/Relational/TH.hs
@@ -97,6 +97,7 @@ import Database.Relational
 import Database.Relational.InternalTH.Base (defineTuplePi, defineRecordProjections)
 import Database.Relational.Scalar (defineScalarDegree)
 import Database.Relational.Constraint (unsafeDefineConstraintKey)
+import Database.Relational.Monad.BaseType (attachEmptyPlaceholderOffsets, detachPlaceholderOffsets,)
 import Database.Relational.Table (TableDerivable (..))
 import qualified Database.Relational.Table as Table
 import Database.Relational.Relation (derivedRelation)
@@ -432,7 +433,7 @@ unsafeInlineQuery :: TypeQ   -- ^ Query parameter type
 unsafeInlineQuery p r sql qVar' =
   simpleValD (varName qVar')
     [t| Query $p $r |]
-    [|  unsafeTypedQuery $(stringE sql) |]
+    [|  unsafeTypedQuery $ attachEmptyPlaceholderOffsets $(stringE sql) |]
 
 -- | Extract param type and result type from defined Relation
 reifyRelation :: Name           -- ^ Variable name which has Relation type
@@ -455,7 +456,7 @@ inlineQuery :: Name         -- ^ Top-level variable name which has 'Relation' ty
 inlineQuery relVar rel config sufs qns = do
   (p, r) <- reifyRelation relVar
   unsafeInlineQuery (return p) (return r)
-    (relationalQuerySQL config rel sufs)
+    (detachPlaceholderOffsets $ relationalQuerySQL config rel sufs)
     (varCamelcaseName qns)
 
 -- | Generate all templates against defined record like type constructor

--- a/relational-schemas/src/Database/Relational/Schema/SQLite3.hs
+++ b/relational-schemas/src/Database/Relational/Schema/SQLite3.hs
@@ -15,7 +15,7 @@ import Data.Char (toLower, toUpper)
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Map (Map)
 import Data.Time (Day, LocalTime)
-import Database.Relational (Query, unsafeTypedQuery)
+import Database.Relational (Query, unsafeTypedQueryNoPh)
 import Database.Relational.Schema.SQLite3Syscat.IndexInfo
 import Database.Relational.Schema.SQLite3Syscat.IndexList
 import Database.Relational.Schema.SQLite3Syscat.TableInfo
@@ -81,10 +81,10 @@ getType mapFromSql info = do
                     else [t|Maybe $(typ)|]
 
 tableInfoQuerySQL :: String -> String -> Query () TableInfo
-tableInfoQuerySQL db tbl = unsafeTypedQuery $ "pragma " ++ db ++ ".table_info(" ++ tbl ++ ");"
+tableInfoQuerySQL db tbl = unsafeTypedQueryNoPh $ "pragma " ++ db ++ ".table_info(" ++ tbl ++ ");"
 
 indexListQuerySQL :: String -> String -> Query () IndexList
-indexListQuerySQL db tbl = unsafeTypedQuery $ "pragma " ++ db ++ ".index_list(" ++ tbl ++ ");"
+indexListQuerySQL db tbl = unsafeTypedQueryNoPh $ "pragma " ++ db ++ ".index_list(" ++ tbl ++ ");"
 
 indexInfoQuerySQL :: String -> String -> Query () IndexInfo
-indexInfoQuerySQL db idx = unsafeTypedQuery $ "pragma " ++ db ++ ".index_info(" ++ idx ++ ");"
+indexInfoQuerySQL db idx = unsafeTypedQueryNoPh $ "pragma " ++ db ++ ".index_info(" ++ idx ++ ");"


### PR DESCRIPTION
Better solution for https://github.com/khibino/haskell-relational-record/pull/67.

# Problem

Users must refer placeholders by exactly same order as the record fields are defined, and must refer every field exactly once.
Otherwise, the parameter values are bind at unintentional placeholders when executing the SQL.

# Solution

1. To `Relation` and `Record`, add fields for lists containing indices of every record field.
    - Called `placeholderOffsets` in `Record`.
    - The indices for the record fiels are obtained from `Pi` object generated by `makeRelationalRecord`.
1. Concatenate the `placeholderOffsets` of `Record`s by any operators for `Record`s.
1. Accumulate the `placeholderOffsets` of `Record`s by the new monad transformer: `ReferredPlaceholders`.
1. Sort parameters by `placeholderOffsets` before binding to the placeholders of the SQL.

# Left problems

- Current implementation can't properly handle the cases that the order of the placeholders referred in the monad stack differs from the order of the placeholders referred in the composed SQL.
    - Maybe I shouldn't have added the `ReferredPlaceholders` monad transformer.
    - I guess it'd be the best way to add `placeholderOffsets` to any `Column`s used in the `SubQuery` type in some way.
- I'm not sure how to handle the cases that the parameter types are composed by using the `placeholder` function several times.
    - e.g. [The SQL to get columns of a table in DB2](https://github.com/khibino/haskell-relational-record/blob/4bf5e344a5c2df923bae9dae0ba1846508337134/relational-schemas/src/Database/Relational/Schema/IBMDB2.hs#L81-L86).
- And other concerns of mine are noted by `igrep TODO` sign.
