### PR TITLE
Fix descriptions in cabal files

### DIFF
--- a/persistable-types-HDBC-pg/persistable-types-HDBC-pg.cabal
+++ b/persistable-types-HDBC-pg/persistable-types-HDBC-pg.cabal
@@ -2,7 +2,8 @@ name:                persistable-types-HDBC-pg
 version:             0.0.3.5
 synopsis:            HDBC and Relational-Record instances of PostgreSQL extended types
 description:         This package contains HDBC Convertible instances and
-                     Relational-Record persistable instances of PostgreSQL extended types
+                     Relational-Record persistable instances of PostgreSQL extended types.
+                     .
                      Supported extended types: inet, cidr
 homepage:            http://khibino.github.io/haskell-relational-record/
 license:             BSD3

--- a/relational-query-HDBC/relational-query-HDBC.cabal
+++ b/relational-query-HDBC/relational-query-HDBC.cabal
@@ -3,6 +3,7 @@ version:             0.7.1.1
 synopsis:            HDBC instance of relational-query and typed query interface for HDBC
 description:         This package contains the HDBC instance of relational-query and
                      the typed query interface for HDBC.
+                     .
                      Generating Database table definitions and functions for
                      relational-query by reading table and index definitions
                      from Database system catalogs.

--- a/relational-query/relational-query.cabal
+++ b/relational-query/relational-query.cabal
@@ -4,7 +4,9 @@ synopsis:            Typeful, Modular, Relational, algebraic query engine
 description:         This package contiains typeful relation structure and
                      relational-algebraic query building DSL which can
                      translate into SQL query.
+                     .
                      Supported query features are below:
+                     .
                      - Type safe query building
                      - Restriction, Join, Aggregation
                      - Modularized relations

--- a/relational-schemas/relational-schemas.cabal
+++ b/relational-schemas/relational-schemas.cabal
@@ -2,7 +2,9 @@ name:                relational-schemas
 version:             0.1.6.2
 synopsis:            RDBMSs' schema templates for relational-query
 description:         This package contains some RDBMSs' schema structure definitions.
+                     .
                      Supported RDBMS schemas are below:
+                     .
                      - IBM DB2
                      - PostgreSQL
                      - Microsoft SQLServer

--- a/text-postgresql/text-postgresql.cabal
+++ b/text-postgresql/text-postgresql.cabal
@@ -3,6 +3,7 @@ version:             0.0.3.1
 synopsis:            Parser and Printer of PostgreSQL extended types
 description:         This package involves parser and printer for
                      text expressions of PostgreSQL extended types.
+                     .
                      - inet type, cidr type
 homepage:            http://khibino.github.io/haskell-relational-record/
 license:             BSD3


### PR DESCRIPTION
To render descriptions properly, Dot is needed at blank lines.

> https://www.haskell.org/cabal/users-guide/developing-packages.html#package-descriptions
> To get a blank line in a field value, use an indented “.”

### Before fix

![スクリーンショット 2019-03-16 8 59 06](https://user-images.githubusercontent.com/3477497/54467739-6bdb2280-47ca-11e9-854c-d3b7a80be6d9.png)

### After fix

![スクリーンショット 2019-03-16 8 58 57](https://user-images.githubusercontent.com/3477497/54467742-71d10380-47ca-11e9-9618-12c96e63cc98.png)
